### PR TITLE
Generic sadness

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ pip install colorama
 # If there is a --file [file name] flag then it will run the file in the filename
 # If there is a --check flag then it will only do compile-time and show warnings
 python n.py
+
+# OPTIONAL: Check the code for accidental errors
+pylint **/*.py --disable=all --enable=E*,F*
 ```
 
 ### Features to add:

--- a/python/function.py
+++ b/python/function.py
@@ -26,4 +26,4 @@ class Function(Variable):
 				return value
 
 	def __str__(self):
-		return display_type(self.arguments, False)
+		return '<function %s>' % display_type(self.arguments, False)

--- a/python/function.py
+++ b/python/function.py
@@ -2,7 +2,7 @@ from variable import Variable
 from type_check_error import display_type
 
 class Function(Variable):
-	def __init__(self, scope, arguments, returntype, codeblock):
+	def __init__(self, scope, arguments, returntype, codeblock, generics=[]):
 		# Tuples represent function types. (a, b, c) represents a -> b -> c.
 		types = tuple([ty for _, ty in arguments] + [returntype])
 		super(Function, self).__init__(types, self)
@@ -11,6 +11,7 @@ class Function(Variable):
 		self.arguments = arguments
 		self.returntype = returntype
 		self.codeblock = codeblock
+		self.generics = generics
 
 	def run(self, arguments):
 		scope = self.scope.new_scope(parent_function=self)

--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -2,25 +2,26 @@ import math
 
 from function import Function
 from type_check_error import display_type
+from type import NGenericType
 
-def substr(s, st, en):
+def substr(start, end, string):
 	try:
-		return s[st:en]
+		return string[start:end]
 	except:
 		return ""
 
-def char_at(s, i):
+def char_at(index, string):
 	try:
-		return s[i]
+		return string[index]
 	except:
 		return ""
 
-def length(s):
+def length(string):
 	try:
-		return len(s)
+		return len(string)
 	except:
 		try:
-			return len(str(s))
+			return len(str(string))
 		except:
 			return 0
 
@@ -36,62 +37,62 @@ def add_funcs(global_scope):
 		"intInBase10",
 		[("number", "int")],
 		"str",
-		lambda number: str(number),
+		str,
 	)
 
 	global_scope.add_native_function(
 		"round",
 		[("number", "float")],
 		"int",
-		lambda number: round(number),
+		round,
 	)
 	global_scope.add_native_function(
 		"floor",
 		[("number", "float")],
 		"int",
-		lambda number: math.floor(number),
+		math.floor,
 	)
 	global_scope.add_native_function(
 		"ceil",
 		[("number", "float")],
 		"int",
-		lambda number: math.ceil(number),
+		math.ceil,
 	)
 	global_scope.add_native_function(
 		"charCode",
 		[("character", "char")],
 		"int",
-		lambda character: ord(character),
+		ord,
 	)
 	global_scope.add_native_function(
 		"intCode",
 		[("number", "int")],
 		"char",
-		lambda number: chr(number),
+		chr,
 	)
 	global_scope.add_native_function(
 		"charAt",
 		[("location", "int"), ("string", "str")],
 		"char",
-		lambda string, location: char_at(string, location),
+		char_at,
 	)
 	global_scope.add_native_function(
 		"substring",
 		[("start", "int"), ("end", "int"), ("string", "str")],
 		"char",
-		lambda string, start, end: substr(string, start, end),
+		substr,
 	)
 	global_scope.add_native_function(
 		"len",
-		[("obj", "any")],
+		[("obj", NGenericType("t"))],
 		"int",
-		lambda obj: length(obj),
+		length,
 	)
 	global_scope.add_native_function(
 		"type",
-		[("obj", "any")],
+		[("obj", NGenericType("t"))],
 		"str",
-		lambda obj: type_display(obj),
+		type_display,
 	)
 
 	global_scope.types['str'] = 'str'

--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -23,7 +23,7 @@ def length(s):
 			return len(str(s))
 		except:
 			return 0
-			
+
 def type_display(o):
 	if type(o) == Function:
 		return str(o)
@@ -93,3 +93,9 @@ def add_funcs(global_scope):
 		"str",
 		lambda obj: type_display(obj),
 	)
+
+	global_scope.types['str'] = 'str'
+	global_scope.types['char'] = 'char'
+	global_scope.types['int'] = 'int'
+	global_scope.types['float'] = 'float'
+	global_scope.types['bool'] = 'bool'

--- a/python/run.n
+++ b/python/run.n
@@ -10,6 +10,18 @@ let main = [test:int test1:str] -> bool {
 	return false
 }
 
+let singleton = [[t] item: t] -> list[t] {
+  let list: list[t] = [item]
+  return list
+}
+print <singleton \t>
+
+let pairSingleton = [[a, b] item1:a item2:b] -> list[(a, b)] {
+  let pair: (a, b) = (item1, item2)
+  return [pair]
+}
+// print <pairSingleton 1 "2">
+
 let wowowo = {
   ok: (3, (("happy", \r), true))
   uwu: "ok"//; extra: 3.4; extra2: 5.4

--- a/python/run.n
+++ b/python/run.n
@@ -20,7 +20,7 @@ let pairSingleton = [[a, b] item1:a item2:b] -> list[(a, b)] {
   let pair: (a, b) = (item1, item2)
   return [pair]
 }
-// print <pairSingleton 1 "2">
+print <pairSingleton 1 "2">
 
 let wowowo = {
   ok: (3, (("happy", \r), true))

--- a/python/scope.py
+++ b/python/scope.py
@@ -159,7 +159,7 @@ class Scope:
 				list_token, contained_type = tree_or_token.children
 				return [list_token, self.parse_type(contained_type, err=err)]
 			elif tree_or_token.data == "tupledef":
-				return [self.parse_type(child) for child in tree_or_token.children]
+				return [self.parse_type(child, err=err) for child in tree_or_token.children]
 			elif err:
 				raise NameError("Type annotation of type %s; I am not ready for this." % tree_or_token.data)
 			else:

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -44,13 +44,14 @@ function_dec_call: NAME (" " [name_type (" " name_type)*])?
 function_call : value (" " value)*
 anonymous_function_call : anonymous_func (" " value)*
 code_block: "{" instruction* "}"
-function_def: arguments ["->" NAME] code_block
-arguments: "[" (name_type (" " name_type)*)? "]"
+function_def: arguments ["->" types] code_block
+arguments: "[" generic_declaration? (name_type (" " name_type)*)? "]"
+generic_declaration: "[" (NAME ",")* NAME "]"
 anonymous_func: "(" arguments "->" NAME ":" (instruction (";" instruction)*) ")"
 char: "\\" ( escape_code | "{" /./ "}")
 escape_code: /[tnr]/
-tupledef: "(" NAME ("," NAME)* ")"
-listdef: LIST "[" NAME "]"
+tupledef: "(" types ("," types)* ")"
+listdef: LIST "[" types "]"
 tupleval: "(" value ("," value)* ")"
 listval: "[" (value ("," value)*)? "]"
 recordval: "{" (record_entry (";" | "\n"))* record_entry (";" | "\n")? "}"

--- a/python/type.py
+++ b/python/type.py
@@ -1,0 +1,10 @@
+class NType:
+	def __init__(self, name):
+		self.name = name
+
+class NGenericType(NType):
+	def __init__(self, name):
+		super(NGenericType, self).__init__(name)
+
+def apply_generics(expected, actual, generics={}):
+	pass

--- a/python/type.py
+++ b/python/type.py
@@ -1,3 +1,5 @@
+import lark
+
 class NType:
 	def __init__(self, name):
 		self.name = name
@@ -6,5 +8,55 @@ class NGenericType(NType):
 	def __init__(self, name):
 		super(NGenericType, self).__init__(name)
 
-def apply_generics(expected, actual, generics={}):
-	pass
+def type_is_list(maybe_list_type):
+	if isinstance(maybe_list_type, list) and len(maybe_list_type) > 0 and type(maybe_list_type[0]) == lark.Token and maybe_list_type[0].type == "LIST":
+		if len(maybe_list_type) > 1:
+			return maybe_list_type[1]
+		else:
+			return "infer"
+	return False
+
+"""
+`expected` is the type of the function's argument.
+`actual` is the type of the expression being passed in.
+"""
+def apply_generics(expected, actual, generics):
+	if isinstance(expected, NGenericType):
+		generic = generics.get(expected)
+		if generic is None:
+			generics[expected] = actual
+			return actual
+		else:
+			return generic
+	elif isinstance(expected, tuple) and isinstance(actual, tuple):
+		return tuple(apply_generics(expected_arg, actual_arg, generic_types, generics) for expected_arg, actual_arg in zip(expected, actual))
+	elif isinstance(expected, list) and isinstance(actual, list):
+		expected_contained_type = type_is_list(expected)
+		actual_contained_type = type_is_list(actual)
+		if expected_contained_type and actual_contained_type:
+			return [lark.Token("LIST", "list"), apply_generics(expected_contained_type, actual_contained_type, generic_types, generics)]
+		elif not expected_contained_type and not actual_contained_type:
+			return [apply_generics(expected_item, actual_item, generic_types, generics) for expected_item, actual_item in zip(expected, actual)]
+	elif isinstance(expected, dict):
+		return {key: apply_generics(expected_type, actual[key], generic_types, generics) if key in actual else expected_type for key, expected_type in expected.items()}
+	return expected
+
+def apply_generics_to(return_type, generics):
+	if isinstance(return_type, NGenericType):
+		generic = generics.get(return_type)
+		if generic is None:
+			return return_type
+		else:
+			return generic
+	elif isinstance(return_type, tuple):
+		return tuple(apply_generics_to(arg_type, generics) for arg_type in return_type)
+	elif isinstance(return_type, list):
+		contained_type = type_is_list(return_type)
+		if contained_type is None:
+			return [apply_generics_to(item_type, generics) for item_type in return_type]
+		else:
+			return [lark.Token("LIST", "list"), apply_generics_to(contained_type, generics)]
+	elif isinstance(return_type, dict):
+		return {key: apply_generics_to(field_type, generics) for key, field_type in return_type.items()}
+	else:
+		return return_type

--- a/python/type_check_error.py
+++ b/python/type_check_error.py
@@ -1,5 +1,6 @@
 import lark
 from colorama import Fore, Style
+from type import NType
 
 class TypeCheckError:
 	def __init__(self, token_or_tree, message):
@@ -21,7 +22,7 @@ class TypeCheckError:
 		output += ": %s\n" % self.message
 		spaces = " "*(len(str(file.line_num_width + 1) + " |") - 1)
 		if type(self.datum) is lark.Token:
-			
+
 			output += f"{Fore.CYAN}{spaces}--> {Fore.BLUE}{file.name}:{self.datum.line}:{self.datum.column}{Style.RESET_ALL}\n"
 			output += file.display(
 				self.datum.line,
@@ -57,7 +58,9 @@ def display_type(n_type, color=True):
 			display = '(' + ', '.join(display_type(type, False) for type in n_type) + ')'
 	elif isinstance(n_type, dict):
 		display = "{ %s }" % "; ".join('%s: %s' % (key, display_type(value, False)) for key, value in n_type.items())
+	elif isinstance(n_type, NType):
+		display = n_type.name
 	else:
-		print('display_type was given a value that is neither a string nor a tuple nor a list nor a dictionary.', n_type)
+		print('display_type was given a value that is neither a string nor a tuple nor a list nor a dictionary nor an NType.', n_type)
 		return Fore.RED + '???' + Style.RESET_ALL if color else "???"
 	return Fore.YELLOW + display + Style.RESET_ALL if color else display


### PR DESCRIPTION
A preview:

Types will be scoped, and `str` `int` etc. will become global-scope types.

```ts
[t][item: t] -> list[t] {
  let list: list[t] = item
  return list
}
```

The above will be the syntax for generics. `[t]` before the parameters declares the generic type, and it defines it in a new scope for the function parameters (if we add traits in the future, they can be specified there). Then, `t` can be used as a type within the function.

In Python, the new type `t` will be represented as an instance of a new class NType, `NType('t')`.  Type instances will be compared by reference, so `NType('t') == NType('t')` should be False, but `t = NType('t'); t == t` should be True.

This function generates a type signature represented in Python as `t = NType('t'); (t, [Token('LIST'), t])`.

Then, there will be a helper method to validate generic types. Something like

```py
t = NType('t')
# validate_types(function_type, argument_types)
validate_types((t, [Token('LIST'), t], [Token('LIST'), t]), ['int', [Token('LIST'), 'str']])
```

On stumbling upon matching `t` and `'int'`, although it is not a match, `t` is known to be a generic (maybe NType should be `NGenericType`? or a boolean property generic for NType, like `NType('t', True)`). (Care must be taken because `t` can be matched with another generic!) Thus, the function type will be replaced with `('int', [Token('LIST'), 'int'], [Token('LIST'), 'int'])` and the checking continues.

Since the actual return type will be known after this process, this helper function will also be used to determine the return type of the function in the same step.

I will not think about the actual representation of the generic function's type signature in N (because the Python branch's type signature syntax is a bit behind).