### PR TITLE
Fix errors and warnings not propagating back up slopes

### DIFF
--- a/python/n.py
+++ b/python/n.py
@@ -29,7 +29,7 @@ with open(filename, "r") as f:
 	file = File(f)
 
 def type_check(file, tree):
-	scope = global_scope.new_scope()
+	scope = global_scope.new_scope(inherit_errors=False)
 	if tree.data == "start":
 		for child in tree.children:
 			scope.type_check_command(child)
@@ -59,7 +59,7 @@ except lark.exceptions.UnexpectedCharacters as e:
 		if e.get_context(file.get_text(), 99999999999999)[0:-2].strip() == line.strip():
 			break
 
-	
+
 	spaces = " "*(len(str(i+1) + " |") +  1)
 	spaces_arrow = " "*(len(str(i+1) + " |") - 3)
 	print(f"{Fore.RED}{Style.BRIGHT}Error{Style.RESET_ALL}: Invalid syntax")

--- a/python/run.n
+++ b/python/run.n
@@ -21,8 +21,10 @@ print <singleton \t>
 
 let pairSingleton = [[a, b] item1:a item2:b] -> list[(a, b)] {
   let pair: (a, b) = (item1, item2)
+  let type_error: int = "wow"
   return [pair]
 }
+let type_error2: int = "wow"
 print <pairSingleton 1 "2">
 
 let wowowo = {

--- a/python/scope.py
+++ b/python/scope.py
@@ -54,7 +54,7 @@ def parse_file(file, check=False):
 	return import_scope, file
 
 def type_check(file, tree, import_scope):
-	scope = import_scope.new_scope()
+	scope = import_scope.new_scope(inherit_errors=False)
 	if tree.data == "start":
 		for child in tree.children:
 			scope.type_check_command(child)
@@ -110,20 +110,20 @@ class Scope:
 		self.imports = imports
 		self.variables = {}
 		self.types = {}
-		self.errors = errors[:]
-		self.warnings = warnings[:]
+		self.errors = errors
+		self.warnings = warnings
 
 	def find_import(self, name):
 		for imp in self.imports:
 			if imp.__name__ == "libraries." + name:
 				return imp
 
-	def new_scope(self, parent_function=None):
+	def new_scope(self, parent_function=None, inherit_errors=True):
 		return Scope(
 			self,
 			parent_function=parent_function or self.parent_function,
-			errors=self.errors,
-			warnings=self.warnings,
+			errors=self.errors if inherit_errors else [],
+			warnings=self.warnings if inherit_errors else [],
 			imports=self.imports,
 		)
 

--- a/python/scope.py
+++ b/python/scope.py
@@ -64,7 +64,7 @@ def type_check(file, tree, import_scope):
 
 def parse_tree(tree, import_scope):
 	if tree.data == "start":
-		scope = import_scope.new_scope()
+		scope = import_scope.new_scope(inherit_errors=False)
 		for child in tree.children:
 			scope.eval_command(child)
 		return scope

--- a/python/type_check_error.py
+++ b/python/type_check_error.py
@@ -41,6 +41,9 @@ class TypeCheckError:
 			)
 		return output
 
+	def __repr__(self):
+		return 'TypeCheckError(%s, %s)' % (repr(self.datum), repr(self.message))
+
 def display_type(n_type, color=True):
 	display = ""
 	if isinstance(n_type, str):


### PR DESCRIPTION
Errors and warnings are now passed by reference again, but when creating an inner scope from import_scope, I've added an option to break the chain of shared errors/warnings