### PR TITLE
Make the maybe type a global type, and fix destructuring enums with generics

### DIFF
--- a/python/enums.py
+++ b/python/enums.py
@@ -1,4 +1,4 @@
-from type import NTypeVars
+from type import NTypeVars, apply_generics_to
 
 class EnumType(NTypeVars):
 	def __init__(self, name, variants, typevars=[], original=None):
@@ -8,7 +8,7 @@ class EnumType(NTypeVars):
 	def get_types(self, variant_name):
 		for variant, types in self.variants:
 			if variant == variant_name:
-				return types
+				return apply_generics_to(types, dict(zip(self.base_type.typevars, self.typevars)))
 		return None
 
 	def new_child(self, typevars):

--- a/python/run.n
+++ b/python/run.n
@@ -11,10 +11,10 @@ if let <dead wow ok> = billy {
   print (wow, ok)
 }
 
-type maybe[t] = <yes t>
-  | nothing
-let ok: maybe[str] = nothing
-print (ok = nothing)
+type myMaybe[t] = <myYes t>
+  | myNothing
+let ok: myMaybe[str] = myNothing
+print (ok = myNothing)
 
 alias pair[t] = (t, t)
 alias strPair = pair[str]
@@ -83,8 +83,15 @@ print c
 print <round 10.1>
 
 print "a"
-        |> <charAt 0>
-        |> <charCode>
+  |> <charAt 1>
+  |> <default <intCode 0>>
+  |> <charCode>
+
+if let <yes char> = ("a"
+  |> <charAt 0>) {
+  print char
+    |> <charCode>
+}
 
 if false {
 	print "test of a thing"


### PR DESCRIPTION
`charAt` and `itemAt` now return `maybe[t]` because the index can be out of bounds. There's also a `default` function to serve as a default value for `maybe` types.