### PR TITLE
Add cmd type for asynchronous/non-pure functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ pip install lark
 # Coloured console text
 pip install colorama
 
+# Async requests
+pip install aiohttp
+
 # Parses and interprets code
 # If there are no arguments then it will interpret run.n
 # If there is a --file [file name] flag then it will run the file in the filename

--- a/python/cmd.py
+++ b/python/cmd.py
@@ -1,0 +1,42 @@
+import inspect
+
+"""
+An immutable class representing a command, which is anything that has a side
+effect or is asynchronous.
+"""
+class Cmd:
+	def __init__(self, performer_getter, map_functions=[], dependent=None):
+		# A function that returns a function that performs the side effect,
+		# given the result from `dependent`. This ideally should be pure.
+		self.performer_getter = performer_getter
+
+		# Transform functions to perform on the resulting value
+		self.map_functions = []
+
+		# A Cmd that should be performed first before performing this command.
+		# The result from this Cmd will be passed to `performer_getter` for this
+		# Cmd's command.
+		self.dependent = dependent
+
+	def map(self, function):
+		return type(self)(self.performer_getter, map_functions=[*self.map_functions, function], dependent=self.dependent)
+
+	def then(self, then_command_getter):
+		return type(self)(then_command_getter, dependent=self)
+
+	async def eval(self):
+		if self.dependent:
+			result = await self.dependent.eval()
+		else:
+			result = ()
+		for function in self.map_functions:
+			result = function(result)
+		performer = self.performer_getter(result)
+		maybe_awaitable = performer()
+		if inspect.isawaitable(maybe_awaitable):
+			return await maybe_awaitable
+		else:
+			return maybe_awaitable
+
+	def __repr__(self):
+		return 'Cmd(%s, map_functions=%s, dependent=%s)' % (repr(self.performer_getter), repr(self.map_functions), repr(self.dependent))

--- a/python/display.py
+++ b/python/display.py
@@ -2,7 +2,7 @@ from colorama import Fore, Style
 from function import Function
 from type import NModule
 from enums import EnumValue
-from native_types import Cmd
+from cmd import Cmd
 
 unescape = {
 	"\\": "\\",

--- a/python/display.py
+++ b/python/display.py
@@ -1,6 +1,8 @@
 from colorama import Fore, Style
 from function import Function
+from type import NModule
 from enums import EnumValue
+from native_types import Cmd
 
 unescape = {
 	"\\": "\\",
@@ -11,7 +13,11 @@ unescape = {
 }
 
 def display_value(value, color=True, indent="\t", indent_state=""):
-	if isinstance(value, dict):
+	if isinstance(value, NModule):
+		output = "[module %s]" % value.mod_name
+		if color:
+			output = Fore.MAGENTA + output + Style.RESET_ALL
+	elif isinstance(value, dict):
 		if len(value) == 0:
 			output = "{}"
 		else:
@@ -63,6 +69,10 @@ def display_value(value, color=True, indent="\t", indent_state=""):
 			for value in value.values:
 				output += inner_indent + display_value(value, color=color, indent=indent, indent_state=inner_indent) + '\n'
 			output += indent_state + (Fore.MAGENTA + '>' + Style.RESET_ALL if color else '>')
+	elif isinstance(value, Cmd):
+		output = "[cmd]"
+		if color:
+			output = Fore.MAGENTA + output + Style.RESET_ALL
 	elif isinstance(value, Function):
 		output = "[function]"
 		if color:

--- a/python/libraries/FileIO.py
+++ b/python/libraries/FileIO.py
@@ -1,14 +1,20 @@
-def write(args):
-	with open(str(args[0])[1:-1], "w+") as f:
-		f.write(''.join(args[1:])[1:-1])
+from native_types import n_cmd_type
 
-def append(args):
-	with open(str(args[0])[1:-1], "a+") as f:
-		f.write(''.join(args[1:])[1:-1])
+def write(path, content):
+	with open(path, "w+") as f:
+		f.write(content)
 
-def read(args):
-	with open(str(args[0])[1:-1], "r", encoding="utf-8") as f:
+def append(path, content):
+	with open(path, "a+") as f:
+		f.write(content)
+
+def read(path):
+	with open(path, "r", encoding="utf-8") as f:
 		return f.read()
 
 def _values():
-	return {"write": None, "append": None, "read": None}
+	return {
+		"write": ("str", "str", n_cmd_type.with_typevars(["unit"])),
+		"append": ("str", "str", n_cmd_type.with_typevars(["unit"])),
+		"read": ("str", n_cmd_type.with_typevars(["str"])),
+	}

--- a/python/libraries/FileIO.py
+++ b/python/libraries/FileIO.py
@@ -1,16 +1,17 @@
+from aiofile import async_open
 from native_types import n_cmd_type
 
-def write(path, content):
-	with open(path, "w+") as f:
-		f.write(content)
+async def write(path, content):
+	async with async_open(path, "w+") as f:
+		await f.write(content)
 
-def append(path, content):
-	with open(path, "a+") as f:
-		f.write(content)
+async def append(path, content):
+	async with async_open(path, "a+") as f:
+		await f.write(content)
 
-def read(path):
-	with open(path, "r", encoding="utf-8") as f:
-		return f.read()
+async def read(path):
+	async with async_open(path, "r", encoding="utf-8") as f:
+		return await f.read()
 
 def _values():
 	return {

--- a/python/libraries/SystemIO.py
+++ b/python/libraries/SystemIO.py
@@ -1,9 +1,9 @@
 from native_types import n_cmd_type
 
-def inp(args):
-	return input(str(args[0]))
+def inp(question):
+	return input(question)
 
 def _values():
 	return {
-		"inp": n_cmd_type.with_typevars(["str"])
+		"inp": ("str", n_cmd_type.with_typevars(["str"]))
 	}

--- a/python/libraries/SystemIO.py
+++ b/python/libraries/SystemIO.py
@@ -1,7 +1,11 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from native_types import n_cmd_type
 
-def inp(question):
-	return input(question)
+# https://gist.github.com/delivrance/675a4295ce7dc70f0ce0b164fcdbd798
+async def inp(question):
+	with ThreadPoolExecutor(1, "AsyncInput") as executor:
+		return await asyncio.get_event_loop().run_in_executor(executor, input, question)
 
 def _values():
 	return {

--- a/python/libraries/SystemIO.py
+++ b/python/libraries/SystemIO.py
@@ -1,5 +1,9 @@
+from native_types import n_cmd_type
+
 def inp(args):
 	return input(str(args[0]))
 
 def _values():
-	return {"inp": "str"}
+	return {
+		"inp": n_cmd_type.with_typevars(["str"])
+	}

--- a/python/libraries/discordn.py
+++ b/python/libraries/discordn.py
@@ -1,4 +1,5 @@
-import requests
+import aiohttp
+import asyncio
 import json
 from native_types import n_cmd_type
 
@@ -8,9 +9,18 @@ def setId(id):
 	global botid
 	botid = id
 
-def sendMessage(channel, message, tts):
-	r = requests.post(f"https://discord.com/api/channels/{channel}/messages", data=json.dumps({"content": message, "tts": tts}), headers={'Content-Type': "application/json", "Authorization": f"Bot {botid}"})
-	return {"code": r.status_code, "response": r.reason, "text": r.text}
+async def sendMessage(channel, message, tts):
+	async with aiohttp.ClientSession() as session:
+		async with session.get(
+			f"https://discord.com/api/channels/{channel}/messages",
+			data=json.dumps({"content": message, "tts": tts}),
+			headers={'Content-Type': "application/json", "Authorization": f"Bot {botid}"},
+		) as response:
+			return {
+				"code": response.status,
+				"response": response.reason,
+				"text": await response.text(),
+			}
 
 def _values():
 	return {

--- a/python/libraries/discordn.py
+++ b/python/libraries/discordn.py
@@ -3,12 +3,11 @@ import json
 
 botid = ""
 
-def setId(args):
+def setId(id):
 	global botid
-	botid = args[0]
+	botid = id
 
-def sendMessage(args):
-	channel, message, *rest = args
+def sendMessage(channel, message, tts):
 	tts = False
 	if len(rest) == 1:
 		tts = rest[0]
@@ -16,4 +15,8 @@ def sendMessage(args):
 	return {"code": r.status_code, "response": r.reason, "text": r.text}
 
 def _values():
-	return {"setId": None, "sendMessage": {"code": "int", "response": "str", "text": "str"}}
+	return {
+		"setId": ("str", n_cmd_type.with_typevars(["unit"])),
+		# TODO: Should Discord snowflakes be ints or strings?
+		"sendMessage": ("str", "str", "bool", n_cmd_type.with_typevars([{"code": "int", "response": "str", "text": "str"}])),
+	}

--- a/python/libraries/discordn.py
+++ b/python/libraries/discordn.py
@@ -1,5 +1,6 @@
 import requests
 import json
+from native_types import n_cmd_type
 
 botid = ""
 
@@ -8,9 +9,6 @@ def setId(id):
 	botid = id
 
 def sendMessage(channel, message, tts):
-	tts = False
-	if len(rest) == 1:
-		tts = rest[0]
 	r = requests.post(f"https://discord.com/api/channels/{channel}/messages", data=json.dumps({"content": message, "tts": tts}), headers={'Content-Type': "application/json", "Authorization": f"Bot {botid}"})
 	return {"code": r.status_code, "response": r.reason, "text": r.text}
 

--- a/python/libraries/fek.py
+++ b/python/libraries/fek.py
@@ -1,7 +1,8 @@
 import re
+from native_types import n_cmd_type
 
-def paer(args):
-	print(args[0])
+def paer(output):
+	print(output)
 
 def _values():
 	return {

--- a/python/libraries/fek.py
+++ b/python/libraries/fek.py
@@ -4,4 +4,6 @@ def paer(args):
 	print(args[0])
 
 def _values():
-	return {"paer": None}
+	return {
+		"paer": ("str", n_cmd_type.with_typevars(["unit"])),
+	}

--- a/python/libraries/times.py
+++ b/python/libraries/times.py
@@ -1,7 +1,10 @@
 import time
+from native_types import n_cmd_type
 
 def sleep(t):
 	time.sleep(t[0]/1000)
 
 def _values():
-	return {"sleep": None}
+	return {
+		"sleep": ("int", n_cmd_type.with_typevars(["unit"])),
+	}

--- a/python/libraries/times.py
+++ b/python/libraries/times.py
@@ -1,8 +1,9 @@
 import time
+import asyncio
 from native_types import n_cmd_type
 
-def sleep(t):
-	time.sleep(t[0]/1000)
+async def sleep(time):
+	await time.sleep(time[0] / 1000)
 
 def _values():
 	return {

--- a/python/n.py
+++ b/python/n.py
@@ -1,6 +1,10 @@
 from lark import Lark
 import lark
 import asyncio
+import sys
+# https://github.com/encode/httpx/issues/914#issuecomment-622586610
+if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 import argparse
 from colorama import init, Fore, Style
 init()

--- a/python/n.py
+++ b/python/n.py
@@ -1,5 +1,6 @@
 from lark import Lark
 import lark
+import asyncio
 import argparse
 from colorama import init, Fore, Style
 init()
@@ -9,6 +10,7 @@ from native_functions import add_funcs
 from type_check_error import TypeCheckError
 from scope import Scope
 from imported_error import ImportedError
+from cmd import Cmd
 
 global_scope = Scope()
 add_funcs(global_scope)
@@ -60,6 +62,9 @@ def parse_tree(tree):
 		scope = global_scope.new_scope()
 		for child in tree.children:
 			scope.eval_command(child)
+		for variable in reversed(scope.variables.values()):
+			if variable.public and isinstance(variable.value, Cmd):
+				asyncio.run(variable.value.eval())
 	else:
 		raise SyntaxError("Unable to run parse_tree on non-starting branch")
 

--- a/python/n.py
+++ b/python/n.py
@@ -69,6 +69,7 @@ def parse_tree(tree):
 		for variable in reversed(scope.variables.values()):
 			if variable.public and isinstance(variable.value, Cmd):
 				asyncio.run(variable.value.eval())
+				break
 	else:
 		raise SyntaxError("Unable to run parse_tree on non-starting branch")
 

--- a/python/native_function.py
+++ b/python/native_function.py
@@ -1,6 +1,7 @@
 from function import Function
 from type_check_error import display_type
-from native_types import n_cmd_type, Cmd
+from native_types import n_cmd_type
+from cmd import Cmd
 
 class NativeFunction(Function):
 	def __init__(self, scope, arguments, return_type, function, argument_cache=[]):
@@ -21,5 +22,7 @@ class NativeFunction(Function):
 	def from_imported(cls, scope, types, function):
 		*arg_types, return_type = types
 		if return_type.base_type is n_cmd_type:
-			function = lambda *args: Cmd(lambda: function(*args))
-		return cls(scope, [("whatever", typ) for typ in arg_types], return_type, function)
+			run_function = lambda *args: Cmd(lambda _: lambda: function(*args))
+		else:
+			run_function = function
+		return cls(scope, [("whatever", typ) for typ in arg_types], return_type, run_function)

--- a/python/native_function.py
+++ b/python/native_function.py
@@ -1,5 +1,6 @@
 from function import Function
 from type_check_error import display_type
+from native_types import n_cmd_type, Cmd
 
 class NativeFunction(Function):
 	def __init__(self, scope, arguments, return_type, function, argument_cache=[]):
@@ -15,3 +16,10 @@ class NativeFunction(Function):
 
 	def __str__(self):
 		return display_type(self.arguments, False)
+
+	@classmethod
+	def from_imported(cls, scope, types, function):
+		*arg_types, return_type = types
+		if return_type.base_type is n_cmd_type:
+			function = lambda *args: Cmd(lambda: function(*args))
+		return cls(scope, [("whatever", typ) for typ in arg_types], return_type, function)

--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -4,17 +4,9 @@ import lark
 from variable import Variable
 from function import Function
 from type_check_error import display_type
-from type import NGenericType, NListType, n_list_type
+from type import NGenericType
 from enums import EnumType, EnumValue
-
-maybe_generic = NGenericType("t")
-n_maybe_type = EnumType("maybe", [
-	("yes", [maybe_generic]),
-	("none", []),
-], [maybe_generic])
-none = EnumValue("none")
-def yes(value):
-	return EnumValue("yes", [value])
+from native_types import n_list_type, n_cmd_type, n_maybe_type, maybe_generic, none, yes
 
 def substr(start, end, string):
 	try:
@@ -145,4 +137,5 @@ def add_funcs(global_scope):
 	global_scope.types['float'] = 'float'
 	global_scope.types['bool'] = 'bool'
 	global_scope.types['list'] = n_list_type
+	global_scope.types['cmd'] = n_cmd_type
 	global_scope.types['maybe'] = n_maybe_type

--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -46,6 +46,9 @@ def with_default(default_value, maybe_value):
 	else:
 		return default_value
 
+def cmd_then(n_function, cmd):
+	return cmd.then(lambda result: n_function.run([result]).eval)
+
 # Define global functions/variables
 def add_funcs(global_scope):
 	global_scope.variables["none"] = Variable(n_maybe_type, none)
@@ -111,24 +114,34 @@ def add_funcs(global_scope):
 		"str",
 		type_display,
 	)
-	generic = NGenericType("t")
+	item_at_generic = NGenericType("t")
 	global_scope.add_native_function(
 		"itemAt",
-		[("index", "int"), ("list", n_list_type.with_typevars([generic]))],
-		n_maybe_type.with_typevars([generic]),
+		[("index", "int"), ("list", n_list_type.with_typevars([item_at_generic]))],
+		n_maybe_type.with_typevars([item_at_generic]),
 		item_at
 	)
+	yes_generic = NGenericType("t")
 	global_scope.add_native_function(
 		"yes",
-		[("value", maybe_generic)],
-		n_maybe_type,
+		[("value", n_maybe_type.with_typevars([yes_generic]))],
+		yes_generic,
 		yes,
 	)
+	default_generic = NGenericType("t")
 	global_scope.add_native_function(
 		"default",
-		[("default", maybe_generic), ("maybeValue", n_maybe_type)],
-		maybe_generic,
+		[("default", default_generic), ("maybeValue", n_maybe_type.with_typevars([default_generic]))],
+		default_generic,
 		with_default,
+	)
+	map_generic_in = NGenericType("a")
+	map_generic_out = NGenericType("b")
+	global_scope.add_native_function(
+		"then",
+		[("thenFunction", (map_generic_in, n_cmd_type.with_typevars([map_generic_out]))), ("cmd", n_cmd_type.with_typevars([map_generic_in]))],
+		n_cmd_type.with_typevars([map_generic_out]),
+		cmd_then,
 	)
 
 	global_scope.types['str'] = 'str'

--- a/python/native_types.py
+++ b/python/native_types.py
@@ -1,0 +1,17 @@
+from type import NTypeVars, NGenericType
+from enums import EnumType, EnumValue
+
+list_generic = NGenericType("t")
+n_list_type = NTypeVars("list", [list_generic])
+
+cmd_generic = NGenericType("t")
+n_cmd_type = NTypeVars("cmd", [cmd_generic])
+
+maybe_generic = NGenericType("t")
+n_maybe_type = EnumType("maybe", [
+	("yes", [maybe_generic]),
+	("none", []),
+], [maybe_generic])
+none = EnumValue("none")
+def yes(value):
+	return EnumValue("yes", [value])

--- a/python/native_types.py
+++ b/python/native_types.py
@@ -7,10 +7,6 @@ n_list_type = NTypeVars("list", [list_generic])
 cmd_generic = NGenericType("t")
 n_cmd_type = NTypeVars("cmd", [cmd_generic])
 
-class Cmd:
-	def __init__(self, function):
-		self.function = function
-
 maybe_generic = NGenericType("t")
 n_maybe_type = EnumType("maybe", [
 	("yes", [maybe_generic]),

--- a/python/native_types.py
+++ b/python/native_types.py
@@ -7,6 +7,10 @@ n_list_type = NTypeVars("list", [list_generic])
 cmd_generic = NGenericType("t")
 n_cmd_type = NTypeVars("cmd", [cmd_generic])
 
+class Cmd:
+	def __init__(self, function):
+		self.function = function
+
 maybe_generic = NGenericType("t")
 n_maybe_type = EnumType("maybe", [
 	("yes", [maybe_generic]),

--- a/python/run.n
+++ b/python/run.n
@@ -74,7 +74,7 @@ for i 15 {
 		})
 }
 
-let test:int = if ! 1 == 1 || 2 > 3 1 else 3
+let test:int = if not 1 == 1 || 2 > 3 1 else 3
 let test1:int = 1 + 1
 let eee:str = "hi"
 
@@ -136,7 +136,6 @@ print ch
 print (0.1 + 0.2 == 0.3)
 
 <main test1 eee>
-<fek.paer "test">
 // print (<fek.paer "test">)
 print (if true { "hi" } else { "hello" })
 if true {
@@ -152,11 +151,7 @@ if <main test eee> {
 
 print (2 + 3 * (4 + 1) * 4 + 5)
 
-
-
-
-
-
+let pub main2 = <fek.paer "test">
 
 // print runner.e runner.e is not public so this throws an error
 print runner.eeeeee

--- a/python/run.n
+++ b/python/run.n
@@ -158,14 +158,12 @@ let printResult = [[t] result:t] -> cmd[()] {
   print result
   return <fek.paer "done">
 }
-let pub temp = <SystemIO.inp "What's your name? ">
+let pub main2 = <SystemIO.inp "What's your name? ">
   |> <then fek.paer>
   |> <then <thenHelper <SystemIO.inp "Discord bot token: ">>>
   |> <then discordn.setId>
   |> <then <thenHelper <discordn.sendMessage "710936824121655396" "uau" false>>>
-
-// let pub main2 = temp
-//   |> <then printResult>
+  |> <then printResult>
 
 // print runner.e runner.e is not public so this throws an error
 print runner.eeeeee

--- a/python/run.n
+++ b/python/run.n
@@ -158,7 +158,7 @@ let printResult = [[t] result:t] -> cmd[()] {
   print result
   return <fek.paer "done">
 }
-let pub main2 = <SystemIO.inp "What's your name? ">
+let pub main2: cmd[()] = <SystemIO.inp "What's your name? ">
   |> <then fek.paer>
   |> <then <thenHelper <SystemIO.inp "Discord bot token: ">>>
   |> <then discordn.setId>

--- a/python/run.n
+++ b/python/run.n
@@ -151,7 +151,21 @@ if <main test eee> {
 
 print (2 + 3 * (4 + 1) * 4 + 5)
 
-let pub main2 = <fek.paer "test">
+let thenHelper = [[t] command:cmd[t] _:()] -> cmd[t] {
+  return command
+}
+let printResult = [[t] result:t] -> cmd[()] {
+  print result
+  return <fek.paer "done">
+}
+let pub temp = <SystemIO.inp "What's your name? ">
+  |> <then fek.paer>
+  |> <then <thenHelper <SystemIO.inp "Discord bot token: ">>>
+  |> <then discordn.setId>
+  |> <then <thenHelper <discordn.sendMessage "710936824121655396" "uau" false>>>
+
+// let pub main2 = temp
+//   |> <then printResult>
 
 // print runner.e runner.e is not public so this throws an error
 print runner.eeeeee

--- a/python/run.n
+++ b/python/run.n
@@ -2,9 +2,12 @@ import fek
 import SystemIO
 import discordn
 
-<discordn?setId "you thought">
-let messageout = <discordn?sendMessage "710936824121655396" "uau">
+print fek
+
+<discordn.setId "you thought">
+let messageout = <discordn.sendMessage "710936824121655396" "uau" false>
 print messageout
+print discordn.sendMessage
 
 type state = <alive float>
   | <dead int list[str]>
@@ -133,8 +136,8 @@ print ch
 print (0.1 + 0.2 == 0.3)
 
 <main test1 eee>
-<fek?paer "test">
-// print (<fek?paer "test">)
+<fek.paer "test">
+// print (<fek.paer "test">)
 print (if true { "hi" } else { "hello" })
 if true {
 	print ("<main test \"hello\"> returned false")

--- a/python/scope.py
+++ b/python/scope.py
@@ -474,6 +474,8 @@ class Scope:
 			operation, value = expr.children
 			if operation.type == "NEGATE":
 				return -self.eval_expr(value)
+			elif operation.type == "NOT":
+				return not self.eval_expr(value)
 			else:
 				raise SyntaxError("Unexpected operation for unary_expression: %s" % operation)
 		elif expr.data == "char":
@@ -772,7 +774,10 @@ class Scope:
 
 		if len(expr.children) == 2 and type(expr.children[0]) is lark.Token:
 			operation, value = expr.children
-			types = unary_operation_types.get(operation.type)
+			operation_type = operation.type
+			if operation_type == "NOT_KW":
+				operation_type = "NOT"
+			types = unary_operation_types.get(operation_type)
 			if types:
 				value_type = self.type_check_expr(value)
 				if value_type is None:

--- a/python/scope.py
+++ b/python/scope.py
@@ -6,9 +6,10 @@ from colorama import Fore, Style
 from variable import Variable
 from function import Function
 from native_function import NativeFunction
-from type import NType, NGenericType, NAliasType, NTypeVars, NListType, n_list_type, apply_generics, apply_generics_to, resolve_equal_types
+from type import NType, NGenericType, NAliasType, NTypeVars, apply_generics, apply_generics_to, resolve_equal_types
 from enums import EnumType, EnumValue, EnumPattern
 from native_function import NativeFunction
+from native_types import n_list_type
 from type_check_error import TypeCheckError, display_type
 from display import display_value
 from operation_types import binary_operation_types, unary_operation_types, comparable_types, iterable_types
@@ -329,7 +330,7 @@ class Scope:
 					return False
 		if isinstance(pattern, list):
 			if warn:
-				if not isinstance(value_or_type, NListType):
+				if not isinstance(value_or_type, NTypeVars) or value_or_type.base_type is not n_list_type:
 					self.errors.append(TypeCheckError(src, "I cannot destructure %s as a list because it's a %s." % (path_name, display_type(value_or_type))))
 					return True
 				contained_type = value_or_type.typevars[0]

--- a/python/scope.py
+++ b/python/scope.py
@@ -187,6 +187,8 @@ class Scope:
 				self.errors.append(TypeCheckError(tree_or_token, "Internal problem: encountered a type %s." % tree_or_token.data))
 				return None
 		else:
+			if tree_or_token.type == "UNIT":
+				return "unit"
 			n_type = self.get_type(tree_or_token.value, err=err)
 			if n_type is None:
 				self.errors.append(TypeCheckError(tree_or_token, "I don't know what type you're referring to by `%s`." % tree_or_token.value))

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -8,58 +8,49 @@ instruction: declare (";")?
            | for (";")?
            | imp (";")?
            | return (";")?
-           | imported_command (";")?
            | if (";")?
            | ifelse (";")?
            | vary (";")?
            | enum_definition (";")?
            | alias_definition (";")?
 
-non_infix_boolval: value
-                 | function_callback
-                 | function_callback_quirky
-                 | function_callback_quirky_pipe
-
 // functions
-vary: "var " NAME "=" (expression | function_def | anonymous_func)
-declare: "let " modifier? name_type "=" (expression | function_def | anonymous_func)
-enum_definition: "type" declaration_with_typevar "=" enum_constructors
-alias_definition: "alias" declaration_with_typevar "=" types
-print: "print" value
-function_callback: "<" (function_call | anonymous_function_call) ">"
-function_callback_quirky: value ".<" (function_call | anonymous_function_call) ">"
-function_callback_quirky_pipe: value "\n" "|>" "<" (function_call | anonymous_function_call) ">"
+vary: "var " NAME "=" expression
+declare: "let " modifier? name_type "=" expression
+enum_definition: "type" declaration_with_typevars "=" enum_constructors
+alias_definition: "alias" declaration_with_typevars "=" types
+print: "print" expression
+function_callback: "<" function_call ">"
+function_callback_quirky: value ".<" function_call ">"
+function_callback_quirky_pipe: value "|>" "<" function_call ">"
 for: "for" name_type NUMBER code_block
 imp: "import" NAME
 impn: "imp" NAME
 return: "return" expression
-imported_command: "<" NAME "?" NAME (" " [value (" " value)*])? ">"
-if: "if" condition ("{"? value "}"? | "{"? instruction "}"? | code_block)
-ifelse: "if" condition ("{"? value "}"? | "{"? instruction "}"? | code_block) "else" ("{"? instruction "}"? | code_block)
+if: "if" condition ("{"? expression "}"? | "{"? instruction "}"? | code_block)
+ifelse: "if" condition ("{"? expression "}"? | "{"? instruction "}"? | code_block) "else" ("{"? instruction "}"? | code_block)
 ifelse_expr: "if" condition "{"? expression "}"? "else" "{"? expression "}"?
 ?condition: expression
           | conditional_let
-conditional_let: "let" cond_pattern "=" (expression | function_def | anonymous_func)
+conditional_let: "let" cond_pattern "=" expression
 
 //helpers
 name_type: definite_pattern [":" types]
 function_dec_call: NAME (" " [name_type (" " name_type)*])?
-function_call : value (" " value)*
-anonymous_function_call : anonymous_func (" " value)*
+function_call : literal (" " literal)*
 code_block: "{" instruction* "}"
 function_def: arguments ["->" types] code_block
 arguments: "[" generic_declaration? (name_type (" " name_type)*)? "]"
 generic_declaration: "[" (NAME ",")* NAME "]"
-anonymous_func: "(" arguments "->" NAME ":" (instruction (";" instruction)*) ")"
+anonymous_func: arguments "->" NAME ":" (instruction (";" instruction)*)
 char: "\\" ( escape_code | "{" /./ "}")
 escape_code: /[tnr]/
 tupledef: "(" types ("," types)* ")"
 with_typevars: NAME "[" types ("," types)* "]"
-declaration_with_typevar: NAME ("[" types ("," types)* "]")?
-tupleval: "(" value ("," value)* ")"
-listval: "[" (value ("," value)*)? "]"
+declaration_with_typevars: NAME ("[" types ("," types)* "]")?
+tupleval: "(" expression ("," expression)* ")"
+listval: "[" (expression ("," expression)*)? "]"
 recordval: "{" (record_entry (";" | "\n"))* record_entry (";" | "\n")? "}"
-record_access: NAME "." NAME
 enum_constructors: enum_constructor ("|" enum_constructor)*
 enum_constructor: "<" NAME types* ">"
                 | NAME
@@ -99,10 +90,12 @@ enum_pattern: "<" NAME any_pattern* ">"
 ?types: NAME
       | tupledef
       | with_typevars
+      | UNIT
 
 ?expression: ifelse_expr
            | boolean_expression
-           | imported_command
+           | function_def
+           | anonymous_func
 
 ?boolean_expression: or_expression
 ?or_expression: [or_expression OR] and_expression
@@ -122,13 +115,16 @@ enum_pattern: "<" NAME any_pattern* ">"
 ?product_expression: [product_expression (MULTIPLY | DIVIDE | ROUNDDIV | MODULO)] exponent_expression
 // Exponentiation right to left associative
 ?exponent_expression: unary_expression [EXPONENT exponent_expression]
-?unary_expression: value
+?unary_expression: record_access
                  | SUBTRACT unary_expression
+?record_access: value
+              | record_access "." NAME
 value: NUMBER
      | BOOLEAN
      | STRING
      | NAME
      | "(" expression ")"
+     | UNIT
      | function_callback
      | function_callback_quirky
      | function_callback_quirky_pipe
@@ -137,7 +133,13 @@ value: NUMBER
      | listval
      | recordval
      | impn
-     | record_access
+
+// Alias for unary_expression. Used for values that visually look tightly bound,
+// which is important for function arguments since they're separated by spaces.
+// For example, <myFunction 1 + 1 2> looks ambiguous; <myFunction (1 + 1) 2>
+// should be used instead. However, <myFunction -num a.b> is pretty clearly
+// <myFunction (-num) (a.b)> so they don't need parentheses.
+?literal: unary_expression
 
 //constants
 BOOLEAN: ("true" | "false")
@@ -159,6 +161,7 @@ ROUNDDIV: "//"
 MODULO: "%"
 EXPONENT: "^"
 PUBLIC: "pub"
+UNIT: "()"
 %import common.ESCAPED_STRING -> STRING
 %import common.SIGNED_NUMBER  -> NUMBER
 %import common.CNAME  -> NAME

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -54,7 +54,7 @@ anonymous_func: "(" arguments "->" NAME ":" (instruction (";" instruction)*) ")"
 char: "\\" ( escape_code | "{" /./ "}")
 escape_code: /[tnr]/
 tupledef: "(" types ("," types)* ")"
-with_typevar: NAME "[" types ("," types)* "]"
+with_typevars: NAME "[" types ("," types)* "]"
 declaration_with_typevar: NAME ("[" types ("," types)* "]")?
 tupleval: "(" value ("," value)* ")"
 listval: "[" (value ("," value)*)? "]"
@@ -98,7 +98,7 @@ enum_pattern: "<" NAME any_pattern* ">"
 
 ?types: NAME
       | tupledef
-      | with_typevar
+      | with_typevars
 
 ?expression: ifelse_expr
            | boolean_expression

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -101,7 +101,7 @@ enum_pattern: "<" NAME any_pattern* ">"
 ?or_expression: [or_expression OR] and_expression
 ?and_expression: [and_expression AND] not_expression
 ?not_expression: compare_expression
-               | NOT not_expression
+               | NOT_KW not_expression
 ?compare_expression: [compare_expression compare_operator] number_expression
 ?compare_operator: EQUALS
                  | GORE
@@ -116,6 +116,7 @@ enum_pattern: "<" NAME any_pattern* ">"
 // Exponentiation right to left associative
 ?exponent_expression: unary_expression [EXPONENT exponent_expression]
 ?unary_expression: record_access
+                 | NOT unary_expression
                  | SUBTRACT unary_expression
 ?record_access: value
               | record_access "." NAME
@@ -152,7 +153,8 @@ LORE: "<="
 LESS: "<"
 GREATER: ">"
 NEQUALS: ("/=" | "!=")
-NOT: ("~" | "!")
+NOT_KW: "not"
+NOT: "~"
 ADD: "+"
 SUBTRACT: "-"
 MULTIPLY: "*"

--- a/python/type.py
+++ b/python/type.py
@@ -56,18 +56,6 @@ class NTypeVars(NType):
 	def __repr__(self):
 		return 'NTypeVars(%s, %s)' % (repr(self.name), repr(self.typevars))
 
-class NListType(NTypeVars):
-	generic = NGenericType("t")
-
-	def __init__(self, name, typevars, original=None):
-		super(NListType, self).__init__(name, typevars, original=original)
-
-	def is_inferred(self):
-		return self.typevars[0] == NListType.generic
-
-n_list_type = NListType("list", [NListType.generic])
-
-
 """
 `expected` is the type of the function's argument, the type with the
 generics/type variables.

--- a/python/type.py
+++ b/python/type.py
@@ -56,6 +56,15 @@ class NTypeVars(NType):
 	def __repr__(self):
 		return 'NTypeVars(%s, %s)' % (repr(self.name), repr(self.typevars))
 
+# N modules are kind of like records but different
+class NModule(dict):
+	def __init__(self, name, *args, **kw):
+		super(NModule, self).__init__(*args, **kw)
+		self.mod_name = name
+		# Prevent destructuring modules completely. This hidden internal field
+		# should never be shown to the casual N programmer.
+		self['not exhaustive'] = True
+
 """
 `expected` is the type of the function's argument, the type with the
 generics/type variables.

--- a/python/type.py
+++ b/python/type.py
@@ -82,6 +82,9 @@ def apply_generics(expected, actual, generics={}):
 		if generic is None:
 			generics[expected] = actual
 			return actual
+		elif isinstance(generic, NGenericType) and not isinstance(actual, NGenericType):
+			generics[expected] = actual
+			return actual
 		else:
 			return generic
 	elif isinstance(expected, NTypeVars) and isinstance(actual, NTypeVars):

--- a/python/type_check_error.py
+++ b/python/type_check_error.py
@@ -1,6 +1,6 @@
 import lark
 from colorama import Fore, Style
-from type import NType, NTypeVars
+from type import NType, NTypeVars, NModule
 
 class TypeCheckError:
 	def __init__(self, token_or_tree, message):
@@ -62,6 +62,8 @@ def display_type(n_type, color=True):
 					display = 'list[]'
 		if display == "":
 			display = '(' + ', '.join(display_type(type, False) for type in n_type) + ')'
+	elif isinstance(n_type, NModule):
+		display = "module %s" % n_type.mod_name
 	elif isinstance(n_type, dict):
 		display = "{ %s }" % "; ".join('%s: %s' % (key, display_type(value, False)) for key, value in n_type.items())
 	elif isinstance(n_type, NTypeVars):

--- a/python/type_check_error.py
+++ b/python/type_check_error.py
@@ -52,7 +52,7 @@ def display_type(n_type, color=True):
 	if isinstance(n_type, str):
 		display = n_type
 	elif isinstance(n_type, tuple):
-		display = ' -> '.join(display_type(type, False) for type in n_type)
+		display = ' -> '.join(('(%s)' if isinstance(type, tuple) else '%s') % display_type(type, False) for type in n_type)
 	elif isinstance(n_type, list):
 		if(type(n_type[0]) == lark.Token):
 			if (n_type[0].type == "LIST"):

--- a/python/variable.py
+++ b/python/variable.py
@@ -5,3 +5,6 @@ class Variable:
 		self.type = t
 		self.value = value
 		self.public = public
+
+	def __repr__(self):
+		return 'Variable(%s, %s, %s)' % (repr(self.type), repr(self.value), repr(self.public))


### PR DESCRIPTION
Currently, n.py just uses the last exported variable that has type `cmd`

```ts
let thenHelper = [[t] command:cmd[t] _:()] -> cmd[t] {
  return command
}
let printResult = [[t] result:t] -> cmd[()] {
  print result
  return <fek.paer "done">
}
let pub main2: cmd[()] = <SystemIO.inp "What's your name? ">
  |> <then fek.paer>
  |> <then <thenHelper <SystemIO.inp "Discord bot token: ">>>
  |> <then discordn.setId>
  |> <then <thenHelper <discordn.sendMessage "710936824121655396" "uau" false>>>
  |> <then printResult>
```

`then` is a `(cmd[a] -> cmd[b]) -> cmd[a] -> cmd[b]` that takes a function and a command. When the command finishes, the function is run on its result to determine the next command to run.

I also added the unit type `()` which is like void in some languages.

This PR doesn't add the await operator `!`; that'll be a separate PR