### PR TITLE
Fix the type checking errors

### DIFF
--- a/python/discord.n
+++ b/python/discord.n
@@ -1,4 +1,5 @@
 import request
+import json
 
 // important variables
 let key:str = ""
@@ -69,8 +70,8 @@ alias reaction = {
 let parseUserData = [data:map[str, str]] -> member{
 	return {
 		id: data
-			  |> <getValue "id">
-			  |> <default "">
+				|> <getValue "id">
+				|> <default "">
 		name: data
 				|> <getValue "username">
 				|> <default "">
@@ -85,7 +86,7 @@ let parseUserData = [data:map[str, str]] -> member{
 }
 
 // public functions
-let pub start = [k:str] -> bool {
+let pub start = [k:str] -> cmd[bool] {
 	var key = k
 	var header = <mapFrom [
 		("Content-Type", "application/json"),
@@ -103,6 +104,23 @@ let pub getKey = [] -> str{
 	return key
 }
 
+let jsonToStrMap = [jsonVal: json.value] -> maybe[map[str, str]] {
+  if let <object map> = jsonVal {
+    return <entries map>
+      |> <filterMap ([(key, value): (str, json.value)] -> maybe[(str, str)] {
+        if let <string str> = value {
+          return <yes (key, str)>
+        } else {
+          return none
+        }
+      })>
+      |> <mapFrom>
+      |> <yes>
+  } else {
+    return none
+  }
+}
+
 let pub getSelf = [] -> cmd[maybe[member]] {
 	// Sends a request to the url
 	let r = <request.get "https://discord.com/api/users/@me" header>!
@@ -110,7 +128,11 @@ let pub getSelf = [] -> cmd[maybe[member]] {
 		return none
 	}
 
-	return <parseUserData r.return>.<yes>
+	if let <yes map> = <jsonToStrMap r.return> {
+		return <parseUserData map>.<yes>
+	} else {
+		return none
+	}
 }
 
 let pub getUser = [id:str] -> cmd[maybe[member]] {
@@ -121,7 +143,11 @@ let pub getUser = [id:str] -> cmd[maybe[member]] {
 		return none
 	}
 
-	return <parseUserData r.return>.<yes>
+	if let <yes map> = <jsonToStrMap r.return> {
+		return <parseUserData map>.<yes>
+	} else {
+		return none
+	}
 }
 
 let pub sendMessage = [c:str m:str] -> cmd[int] {

--- a/python/native_function.py
+++ b/python/native_function.py
@@ -1,3 +1,5 @@
+import inspect
+
 from function import Function
 from type_check_error import display_type
 from native_types import n_cmd_type
@@ -13,7 +15,11 @@ class NativeFunction(Function):
 		arguments = self.argument_cache + arguments
 		if len(arguments) < len(self.arguments):
 			return NativeFunction(self.scope, self.arguments, self.returntype, self.function, argument_cache=self.argument_cache + arguments)
-		return self.function(*arguments)
+		maybe_awaitable = self.function(*arguments)
+		if inspect.isawaitable(maybe_awaitable):
+			return await maybe_awaitable
+		else:
+			return maybe_awaitable
 
 	def __str__(self):
 		return display_type(self.arguments, False)

--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -29,6 +29,14 @@ def length(string):
 	except TypeError:
 		return len(str(string))
 
+async def filter_map(transformer, lis):
+	new_list = []
+	for item in lis:
+		transformed = await transformer.run([item])
+		if transformed.variant == "yes":
+			new_list.append(transformed.values[0])
+	return new_list
+
 def type_display(o):
 	if type(o) == Function:
 		return str(o)
@@ -56,6 +64,11 @@ def map_get(key, map):
 		return none
 	else:
 		return yes(item)
+
+def entries(n_map):
+	# NMap extends dict so it's basically a dict, but this way we can
+	# distinguish between a record and a map.
+	return list(n_map.items())
 
 # Define global functions/variables
 def add_funcs(global_scope):
@@ -148,12 +161,16 @@ def add_funcs(global_scope):
 		n_list_type.with_typevars([item_at_generic]),
 		lambda item, l: l.__add__([item])
 	)
-	item_at_generic = NGenericType("t")
+	filter_map_generic_a = NGenericType("a")
+	filter_map_generic_b = NGenericType("b")
 	global_scope.add_native_function(
-		"itemAt",
-		[("index", "int"), ("list", n_list_type.with_typevars([item_at_generic]))],
-		n_maybe_type.with_typevars([item_at_generic]),
-		item_at
+		"filterMap",
+		[
+			("function", (filter_map_generic_a, n_maybe_type.with_typevars([filter_map_generic_b]))),
+			("list", n_list_type.with_typevars([filter_map_generic_a]))
+		],
+		n_list_type.with_typevars([filter_map_generic_b]),
+		filter_map
 	)
 	yes_generic = NGenericType("t")
 	global_scope.add_native_function(
@@ -192,6 +209,14 @@ def add_funcs(global_scope):
 		[("key", map_get_generic_key), ("map", n_map_type.with_typevars([map_get_generic_key, map_get_generic_value]))],
 		n_maybe_type.with_typevars([map_get_generic_value]),
 		map_get,
+	)
+	entries_generic_key = NGenericType("k")
+	entries_generic_value = NGenericType("v")
+	global_scope.add_native_function(
+		"entries",
+		[("map", n_map_type.with_typevars([map_from_generic_key, map_from_generic_value]))],
+		n_list_type.with_typevars([[map_from_generic_key, map_from_generic_value]]),
+		entries,
 	)
 
 	global_scope.types['str'] = 'str'


### PR DESCRIPTION
Language changes:
- Added filterMap: (a -> maybe[b]) -> list[a] -> list[b]
- Added entries: map[k, v] -> list[(k, v)]; basically reverse mapFrom

N changes:
- Added a helper function that converts a json.value to a maybe[map[str, 
str]]
- `start` now returns a cmd because it uses await

Python changes:
- Can now use imported modules from parent scopes in types
- If a nested type is None, the entire type becomes None
- Support for conditional_let in ifelse
- Clarified error message for using await in a non-cmd-returning 
function