### PR TITLE
Readd support for the old imp syntax for backwards compatibility

### DIFF
--- a/python/run.n
+++ b/python/run.n
@@ -11,6 +11,8 @@ let test = [a:int b:int] -> int {
 }
 
 // let wow = imp "../examples/fizzbuzz.n"
+// let oldSyntax = imp runner
+// print(oldSyntax)
 
 print(test(1, 2)
               |> test(1))

--- a/python/runner.n
+++ b/python/runner.n
@@ -10,4 +10,4 @@ type pub state = <alive float>
 alias pub pair[t] = (t, t)
 alias pub strPair = pair[str]
 
-let pub secret = <alive 3.4>
+let pub secret = alive(3.4)

--- a/python/scope.py
+++ b/python/scope.py
@@ -627,7 +627,11 @@ class Scope:
 			else:
 				return self.eval_value(token_or_tree)
 		elif expr.data == "impn":
-			rel_file_path = bytes(expr.children[0].value[1:-1], 'utf-8').decode('unicode_escape')
+			if expr.children[0].type == "STRING":
+				rel_file_path = bytes(expr.children[0].value[1:-1], 'utf-8').decode('unicode_escape')
+			else:
+				# Support old syntax
+				rel_file_path = expr.children[0].value + ".n"
 			file_path = os.path.join(os.path.dirname(self.file_path), rel_file_path)
 			val = await eval_file(file_path, self.base_path)
 			holder = {}
@@ -1046,7 +1050,11 @@ class Scope:
 
 			return n_list_type.with_typevars([contained_type])
 		elif expr.data == "impn":
-			rel_file_path = bytes(expr.children[0].value[1:-1], 'utf-8').decode('unicode_escape')
+			if expr.children[0].type == "STRING":
+				rel_file_path = bytes(expr.children[0].value[1:-1], 'utf-8').decode('unicode_escape')
+			else:
+				# Support old syntax
+				rel_file_path = expr.children[0].value + ".n"
 			file_path = os.path.join(os.path.dirname(self.file_path), rel_file_path)
 			if os.path.isfile(file_path):
 				impn, f = type_check_file(file_path, self.base_path)

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -23,7 +23,7 @@ function_callback_pipe: literal "|>" function_call
                       | function_callback_pipe "|>" function_call
 for: "for" name_type NUMBER code_block
 imp: "import" NAME
-impn: "imp" STRING
+impn: "imp" (STRING | NAME)
 return: "return" expression
 if: "if" condition ("{" instruction "}" | code_block)
 ifelse: "if" condition ("{" instruction "}" | code_block) "else" ("{" instruction "}" | code_block | ifelse | if)


### PR DESCRIPTION
```ts
let runner = imp runner
// is the same as
let runner = imp "./runner.n"
```

The old syntax is deprecated and perhaps we should remove it in the next major release