### PR TITLE
Add multiline comments to python

### DIFF
--- a/python/run.n
+++ b/python/run.n
@@ -1,22 +1,24 @@
-class pub Test [ok:int] {
-	let test:int = 2 + ok
-
-	let pub thingo = [a:int b:int] -> int{
-		return a + b + test
-	}
-}
-
-let test = [a:int b:int] -> int {
+print("this is a test")
+let sum = [a:int b:int] -> int {
 	return a + b
 }
+print(sum(1, 2))
+if true {
+	print("true is true")
+}
+let test = 3
+test
+  |> sum(1)
+  |> print()
+// same as
+print(sum(1, test))
+let addOne = sum(1)
 
-// let wow = imp "../examples/fizzbuzz.n"
-// let oldSyntax = imp runner
-// print(oldSyntax)
+print(addOne(2)) // prints out 3
 
-print(test(1, 2)
-              |> test(1))
-
-let tester:Test = Test(3)
-
-print(tester.thingo(1, 2))
+/*
+testing
+/*
+testing
+*/
+*/

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -150,6 +150,7 @@ value: NUMBER
 //constants
 BOOLEAN: ("true" | "false")
 COMMENT: "//" /[^\n]/*
+MULTILINE_COMMENT: "/*" /.+(?=\*\/)/*
 OR: ("||" | "|")
 AND: ("&&" | "&")
 EQUALS: ("==" | "=")
@@ -175,3 +176,4 @@ UNIT: "()"
 %import common.WS
 %ignore WS
 %ignore COMMENT
+%ignore MULTILINE_COMMENT

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -149,7 +149,8 @@ value: NUMBER
 
 //constants
 BOOLEAN: ("true" | "false")
-COMMENT: "//" /[^\n]/*
+COMMENT: "/*" /(.|\n|\r)+/ "*/"     
+       | "//" /[^\n]/*
 MULTILINE_COMMENT: "/*" /.+(?=\*\/)/*
 OR: ("||" | "|")
 AND: ("&&" | "&")


### PR DESCRIPTION
Allows for multiline comments to be used in N programs like so:
```js
/*
this is a
multiline comment
*/
```
This does ensure backward compatibility by only adding a feature to the parser.