### PR TITLE
Features and bug fixes

### DIFF
--- a/PROJECTS.md
+++ b/PROJECTS.md
@@ -1,5 +1,3 @@
 # Projects
 - [discord.n](https://github.com/nbuilding/discord.n)
 - [N Libs](https://github.com/Ashvin-Ranjan/N-Libs)
-
-### Project count: 2

--- a/python/classes.py
+++ b/python/classes.py
@@ -24,7 +24,7 @@ class NConstructor(Function):
 				self.scope,
 				self.arguments,
 				self.codeblock,
-				public,
+				self.public,
 				argument_cache=self.argument_cache
 			)
 

--- a/python/libraries/request.py
+++ b/python/libraries/request.py
@@ -5,12 +5,6 @@ import asyncio
 from native_types import n_cmd_type, NMap, n_map_type
 from libraries.json import json_value_type, python_to_json, string
 
-#for gateways
-scope = None
-
-def _prepare(sc):
-	scope = sc
-
 async def get(url, headers):
 	async with aiohttp.ClientSession() as session:
 		async with session.get(url, headers=headers) as r:

--- a/python/libraries/websocket.py
+++ b/python/libraries/websocket.py
@@ -25,7 +25,7 @@ connect_options_type = {
 }
 
 async def connect(options, url):
-	debug = os.environ['N_WS_DEBUG'] == 'experimental'
+	debug = os.environ.get('N_WS_DEBUG') == 'experimental'
 	if debug:
 		print(f"{Fore.YELLOW}Websocket debugging is experimental and may be removed in the future.{Style.RESET_ALL}")
 		print(f"[{url}] {Fore.BLUE}Connecting.{Style.RESET_ALL}")

--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -8,7 +8,7 @@ from function import Function
 from type_check_error import display_type
 from type import NGenericType
 from enums import EnumType, EnumValue
-from native_types import n_list_type, n_map_type, NMap, n_cmd_type, n_maybe_type, none, yes, n_result_type, ok, err
+from native_types import n_list_type, n_map_type, NMap, n_cmd_type, n_maybe_type, maybe_generic, none, yes, n_result_type, result_ok_generic, result_err_generic, ok, err
 
 def substr(start, end, string):
 	return string[start:end]
@@ -194,11 +194,10 @@ def add_funcs(global_scope):
 		n_list_type.with_typevars([filter_map_generic_b]),
 		filter_map
 	)
-	yes_generic = NGenericType("t")
 	global_scope.add_native_function(
 		"yes",
-		[("value", yes_generic)],
-		n_maybe_type.with_typevars([yes_generic]),
+		[("value", maybe_generic)],
+		n_maybe_type.with_typevars([maybe_generic]),
 		yes,
 	)
 	default_generic = NGenericType("t")
@@ -208,20 +207,16 @@ def add_funcs(global_scope):
 		default_generic,
 		with_default,
 	)
-	ok_generic_o = NGenericType("o")
-	ok_generic_e = NGenericType("e")
 	global_scope.add_native_function(
 		"ok",
-		[("value", ok_generic_o)],
-		n_result_type.with_typevars([ok_generic_o, ok_generic_e]),
+		[("value", result_ok_generic)],
+		n_result_type.with_typevars([result_ok_generic, result_err_generic]),
 		ok,
 	)
-	err_generic_o = NGenericType("o")
-	err_generic_e = NGenericType("e")
 	global_scope.add_native_function(
 		"err",
-		[("error", err_generic_e)],
-		n_result_type.with_typevars([err_generic_o, err_generic_e]),
+		[("error", result_err_generic)],
+		n_result_type.with_typevars([result_ok_generic, result_err_generic]),
 		err,
 	)
 	then_generic_in = NGenericType("a")

--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -252,8 +252,8 @@ def add_funcs(global_scope):
 	entries_generic_value = NGenericType("v")
 	global_scope.add_native_function(
 		"entries",
-		[("map", n_map_type.with_typevars([map_from_generic_key, map_from_generic_value]))],
-		n_list_type.with_typevars([[map_from_generic_key, map_from_generic_value]]),
+		[("map", n_map_type.with_typevars([entries_generic_key, entries_generic_value]))],
+		n_list_type.with_typevars([[entries_generic_key, entries_generic_value]]),
 		entries,
 	)
 

--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -8,7 +8,7 @@ from function import Function
 from type_check_error import display_type
 from type import NGenericType
 from enums import EnumType, EnumValue
-from native_types import n_list_type, n_map_type, NMap, n_cmd_type, n_maybe_type, maybe_generic, none, yes
+from native_types import n_list_type, n_map_type, NMap, n_cmd_type, n_maybe_type, none, yes, n_result_type, ok, err
 
 def substr(start, end, string):
 	return string[start:end]
@@ -208,6 +208,22 @@ def add_funcs(global_scope):
 		default_generic,
 		with_default,
 	)
+	ok_generic_o = NGenericType("o")
+	ok_generic_e = NGenericType("e")
+	global_scope.add_native_function(
+		"ok",
+		[("value", ok_generic_o)],
+		n_result_type.with_typevars([ok_generic_o, ok_generic_e]),
+		ok,
+	)
+	err_generic_o = NGenericType("o")
+	err_generic_e = NGenericType("e")
+	global_scope.add_native_function(
+		"err",
+		[("error", err_generic_e)],
+		n_result_type.with_typevars([err_generic_o, err_generic_e]),
+		err,
+	)
 	then_generic_in = NGenericType("a")
 	then_generic_out = NGenericType("b")
 	global_scope.add_native_function(
@@ -250,3 +266,4 @@ def add_funcs(global_scope):
 	global_scope.types['map'] = n_map_type
 	global_scope.types['cmd'] = n_cmd_type
 	global_scope.types['maybe'] = n_maybe_type
+	global_scope.types['result'] = n_result_type

--- a/python/native_types.py
+++ b/python/native_types.py
@@ -22,3 +22,14 @@ n_maybe_type = EnumType("maybe", [
 none = EnumValue("none")
 def yes(value):
 	return EnumValue("yes", [value])
+
+result_ok_generic = NGenericType("o")
+result_err_generic = NGenericType("e")
+n_result_type = EnumType("result", [
+	("ok", [result_ok_generic]),
+	("err", [result_err_generic]),
+], [result_ok_generic, result_err_generic])
+def ok(value):
+	return EnumValue("ok", [value])
+def err(value):
+	return EnumValue("err", [value])

--- a/python/operation_types.py
+++ b/python/operation_types.py
@@ -1,29 +1,25 @@
 from type import NTypeVars
+from native_types import n_list_type, list_generic
 
-# TODO: Move these into Scope because one day these might be scoped due to
+# Might move these into Scope one day because these might be scoped due to
 # implementations of traits.
 binary_operation_types = {
-	"OR": { ("bool", "bool"): "bool", ("int", "int"): "int" },
-	"AND": { ("bool", "bool"): "bool", ("int", "int"): "int" },
-	"ADD": { ("int", "int"): "int", ("float", "float"): "float", ("str", "str"): "str", ("char", "char"): "str", ("str", "char"): "str"},
-	"SUBTRACT": { ("int", "int"): "int", ("float", "float"): "float" },
-	"MULTIPLY": { ("int", "int"): "int", ("float", "float"): "float" },
-	"DIVIDE": { ("int", "int"): "int", ("float", "float"): "float" },
-	"ROUNDDIV": { ("int", "int"): "int", ("float", "float"): "float" },
-	"MODULO": { ("int", "int"): "int", ("float", "float"): "float" },
+	"OR": [("bool", "bool", "bool"), ("int", "int", "int")],
+	"AND": [("bool", "bool", "bool"), ("int", "int", "int")],
+	"ADD": [("int", "int", "int"), ("float", "float", "float"), ("str", "str", "str"), ("char", "char", "str"), ("str", "char", "str"), (n_list_type, n_list_type, n_list_type)],
+	"SUBTRACT": [("int", "int", "int"), ("float", "float", "float")],
+	"MULTIPLY": [("int", "int", "int"), ("float", "float", "float")],
+	"DIVIDE": [("int", "int", "int"), ("float", "float", "float")],
+	"ROUNDDIV": [("int", "int", "int"), ("float", "float", "float")],
+	"MODULO": [("int", "int", "int"), ("float", "float", "float")],
 	# Exponents are weird because negative powers result in non-integers.
-	"EXPONENT": { ("int", "int"): "float", ("float", "float"): "float" },
+	# TODO: Make int ^ int an int; negative powers should result in 0.
+	"EXPONENT": [("int", "int", "float"), ("float", "float", "float")],
 }
 unary_operation_types = {
-	"NEGATE": { "int": "int", "float": "float" },
-	"NOT": { "bool": "bool", "int": "int" },
+	"NEGATE": [("int", "int", "float", "float")],
+	"NOT": [("bool", "bool", "int", "int")],
 }
 comparable_types = ["int", "float"]
-legacy_iterable_types = { "int": "int" }
-_other_iterable_types = {  }
-def iterable_types(iterable_type):
-	if isinstance(iterable_type, NTypeVars):
-		if iterable_type.name == "list":
-			return iterable_type.typevars[0]
-
-	return _other_iterable_types.get(iterable_type)
+legacy_iterable_types = [("int", "int")]
+iterable_types = [(n_list_type, list_generic)]

--- a/python/run.n
+++ b/python/run.n
@@ -1,8 +1,8 @@
-for i 10 {
+for i 3 {
 	print(i)
 }
 
-for (i in range(0, 10, 1)) {
+for (i in range(0, 3, 1)) {
 	print(i)
 }
 
@@ -28,3 +28,10 @@ let test2: [n] (str -> int -> n -> person[n]) -> n -> str -> int -> person[n] = 
 // str -> int -> float -> person[float].
 // print(test(person)(10.1)("wow", 3))
 print(test2(person)(10)("wow", 3))
+
+for (item in ([1, 2] + [3, 4])) {
+  print(item)
+}
+for (item in ([] + [])) {
+  print(item)
+}

--- a/python/run.n
+++ b/python/run.n
@@ -5,3 +5,7 @@ for i 10 {
 for (i in range(0, 10, 1)) {
 	print(i)
 }
+
+alias person = { name: str; age: int; height: float }
+// Canonically Billia-chan is 18 years old for fanservice reasons
+print(person("Billia-chan", 18)(14.3))

--- a/python/run.n
+++ b/python/run.n
@@ -6,7 +6,7 @@ for (i in range(0, 10, 1)) {
 	print(i)
 }
 
-alias person = { name: str; age: int; height: float }
+alias person[n] = { name: str; age: int; height: n }
 // Canonically Billia-chan is 18 years old for fanservice reasons
 print(person("Billia-chan", 18)(14.3))
 
@@ -16,3 +16,15 @@ print(3 / 0) // 0
 
 let wow: result[str, ()] = ok("cool!")
 print(wow)
+
+let test: (str -> int -> float -> person[float]) -> float -> str -> int -> person[float] = [a:str -> int -> float -> person[float] b:float c:str d:int] -> person[float] {
+  return a(c, d, b)
+}
+let test2: [n] (str -> int -> n -> person[n]) -> n -> str -> int -> person[n] = [[n] a:str -> int -> n -> person[n] b:n c:str d:int] -> person[n] {
+  return a(c, d, b)
+}
+// Does not work because str -> int -> n -> person[n] is assumed to use n from
+// an outer function which may not necessarily be float, so it cannot be used as
+// str -> int -> float -> person[float].
+// print(test(person)(10.1)("wow", 3))
+print(test2(person)(10)("wow", 3))

--- a/python/run.n
+++ b/python/run.n
@@ -9,3 +9,7 @@ for (i in range(0, 10, 1)) {
 alias person = { name: str; age: int; height: float }
 // Canonically Billia-chan is 18 years old for fanservice reasons
 print(person("Billia-chan", 18)(14.3))
+
+print(1.0 / -0.0) // -Infinity
+print(0.0 / 0.0) // NaN
+print(3 / 0) // 0

--- a/python/run.n
+++ b/python/run.n
@@ -13,3 +13,6 @@ print(person("Billia-chan", 18)(14.3))
 print(1.0 / -0.0) // -Infinity
 print(0.0 / 0.0) // NaN
 print(3 / 0) // 0
+
+let wow: result[str, ()] = ok("cool!")
+print(wow)

--- a/python/scope.py
+++ b/python/scope.py
@@ -119,6 +119,9 @@ def pattern_to_name(pattern_and_src):
 		return "<destructuring pattern>"
 
 def get_arguments(tree):
+	"""
+	The arguments syntax briefly had the WS token which had to be removed.
+	"""
 	arguments = [tree for tree in tree.children if type(tree) == lark.Tree]
 	if len(arguments) > 0 and arguments[0].data == "generic_declaration":
 		return arguments[0].children, arguments[1:]

--- a/python/scope.py
+++ b/python/scope.py
@@ -217,14 +217,14 @@ class Scope:
 				elif isinstance(typevar_type, NAliasType) or isinstance(typevar_type, NTypeVars):
 					# Duck typing :sunglasses:
 					if len(typevars) < len(typevar_type.typevars):
-						self.errors.append(TypeCheckError(tree_or_token, "%s expects %d type variable(s)." % (name.value, len(typevar_type.typevars))))
+						self.errors.append(TypeCheckError(tree_or_token, "%s expects %d type variable(s)." % (display_type(typevar_type), len(typevar_type.typevars))))
 						return None
 					elif len(typevars) > len(typevar_type.typevars):
-						self.errors.append(TypeCheckError(tree_or_token, "%s only expects %d type variable(s)." % (name.value, len(typevar_type.typevars))))
+						self.errors.append(TypeCheckError(tree_or_token, "%s only expects %d type variable(s)." % (display_type(typevar_type), len(typevar_type.typevars))))
 						return None
 					return typevar_type.with_typevars(parsed_typevars) if None not in parsed_typevars else None
 				else:
-					self.errors.append(TypeCheckError(tree_or_token, "%s doesn't take any type variables." % name.value))
+					self.errors.append(TypeCheckError(tree_or_token, "%s doesn't take any type variables." % display_type(typevar_type)))
 					return None
 			elif tree_or_token.data == "tupledef":
 				tuple_type = [self.parse_type(child, err=err) for child in tree_or_token.children]
@@ -237,7 +237,7 @@ class Scope:
 				if n_type is None:
 					return None
 				elif (isinstance(n_type, NAliasType) or isinstance(n_type, NTypeVars)) and len(n_type.typevars) > 0:
-					self.errors.append(TypeCheckError(tree_or_token, "%s expects %d type variables." % (type_name.value, len(n_type.typevars))))
+					self.errors.append(TypeCheckError(tree_or_token, "%s expects %d type variables." % (display_type(n_type), len(n_type.typevars))))
 					return None
 				elif isinstance(n_type, NAliasType):
 					return n_type.with_typevars()

--- a/python/scope.py
+++ b/python/scope.py
@@ -707,7 +707,7 @@ class Scope:
 			scope = self.new_scope()
 			if condition.data == "conditional_let":
 				pattern, value = condition.children
-				yes = scope.assign_to_pattern(get_destructure_pattern(pattern), await self.eval_expr(value), certain=True)
+				yes = scope.assign_to_pattern(get_destructure_pattern(pattern), await self.eval_expr(value))
 			else:
 				yes = await self.eval_expr(condition)
 			if yes:
@@ -821,7 +821,7 @@ class Scope:
 			if condition.data == "conditional_let":
 				pattern, value = condition.children
 				eval_type = self.type_check_expr(value)
-				scope.assign_to_pattern(get_destructure_pattern(pattern), eval_type, True, certain=True)
+				scope.assign_to_pattern(get_destructure_pattern(pattern), eval_type, True)
 			else:
 				cond_type = self.type_check_expr(condition)
 				if cond_type is not None and cond_type != "bool":
@@ -1029,7 +1029,10 @@ class Scope:
 					# To deal with cases like [[], [3]] as list[int]
 					contained_type = resolved_contained_type
 
-			return n_list_type.with_typevars([contained_type])
+			if contained_type is None:
+				return None
+			else:
+				return n_list_type.with_typevars([contained_type])
 		elif expr.data == "impn":
 			if expr.children[0].type == "STRING":
 				rel_file_path = bytes(expr.children[0].value[1:-1], 'utf-8').decode('unicode_escape')

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -41,7 +41,7 @@ function_dec_call: NAME (" " [name_type (" " name_type)*])?
 function_call: literal "(" [expression ("," expression)*] ")"
 code_block: "{" instruction* "}"
 function_def: arguments ["->" types] code_block
-arguments: "[" generic_declaration? (name_type name_type*)? "]"
+arguments: "[" generic_declaration? (name_type (WS name_type)*)? "]"
 generic_declaration: "[" (NAME ",")* NAME "]"
 anonymous_func: arguments "->" NAME ":" (instruction (";" instruction)*)
 char: "\\" ( escape_code | "{" /./ "}")

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -41,7 +41,8 @@ function_dec_call: NAME (" " [name_type (" " name_type)*])?
 function_call: literal "(" [expression ("," expression)*] ")"
 code_block: "{" instruction* "}"
 function_def: arguments ["->" types] code_block
-arguments: "[" generic_declaration? (name_type (WS name_type)*)? "]"
+arguments: "[" generic_declaration? arg_name_type* "]"
+arg_name_type: definite_pattern [":" types]
 generic_declaration: "[" (NAME ",")* NAME "]"
 anonymous_func: arguments "->" NAME ":" (instruction (";" instruction)*)
 char: "\\" ( escape_code | "{" /./ "}")
@@ -79,6 +80,14 @@ record_pattern: "{" (record_entry_pattern (";" | "\n"))* record_entry_pattern "}
 
 list_pattern: "[" (pattern_value ("," pattern_value)*)? "]"
 enum_pattern: "<" NAME pattern_value* ">"
+
+// Deal with a syntax ambiguity where [a:type[b]] could be seen as a list
+// destructuring in the second argument.
+?definite_pattern: NAME
+                 | "_"
+                 | "(" pattern ")"
+                 | record_pattern
+                 | tuple_pattern
 
 // Boolean and number expressions, with order of operations.
 // Question mark "inlines" the branch, so we don't get nested

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -91,12 +91,17 @@ enum_pattern: "<" NAME any_pattern* ">"
 // Square brackets mean that the stuff inside it can appear 0 or 1 time. Same as
 // (whatever)?
 
-?types: module_type
-      | tupledef
-      | recorddef
-      | with_typevars
-      | UNIT
+?types: not_func_type
+      | func_type
+?not_func_type: module_type
+              | tupledef
+              | recorddef
+              | with_typevars
+              | UNIT
 module_type: [NAME "."]* NAME
+func_type: generic_declaration? (func_inner_type "->")+ not_func_type
+?func_inner_type: not_func_type
+                | "(" func_type ")"
 
 ?expression: ifelse_expr
            | boolean_expression
@@ -151,7 +156,7 @@ value: NUMBER
 
 //constants
 BOOLEAN: ("true" | "false")
-COMMENT: "/*" /(.|\n|\r)+/ "*/"     
+COMMENT: "/*" /(.|\n|\r)+/ "*/"
        | "//" /[^\n]/*
 MULTILINE_COMMENT: "/*" /.+(?=\*\/)/*
 OR: ("||" | "|")

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -32,16 +32,16 @@ ifelse: "if" condition ("{" instruction "}" | code_block) "else" ("{" instructio
 ifelse_expr: "if" condition "{" expression "}" "else" ("{" expression "}" | ifelse_expr)
 ?condition: expression
           | conditional_let
-conditional_let: "let" cond_pattern "=" expression
+conditional_let: "let" pattern "=" expression
 class_definition: "class" modifier NAME arguments code_block
 
 //helpers
-name_type: definite_pattern [":" types]
+name_type: pattern [":" types]
 function_dec_call: NAME (" " [name_type (" " name_type)*])?
 function_call: literal "(" [expression ("," expression)*] ")"
 code_block: "{" instruction* "}"
 function_def: arguments ["->" types] code_block
-arguments: "[" generic_declaration? (name_type (" " name_type)*)? "]"
+arguments: "[" generic_declaration? (name_type name_type*)? "]"
 generic_declaration: "[" (NAME ",")* NAME "]"
 anonymous_func: arguments "->" NAME ":" (instruction (";" instruction)*)
 char: "\\" ( escape_code | "{" /./ "}")
@@ -64,26 +64,21 @@ modifier: PUBLIC?
 ?record_entry: NAME ":" expression
              | NAME
 
-?any_pattern: definite_pattern_value
-            | cond_pattern_value
-
-?definite_pattern: definite_pattern_value
-                 | tuple_pattern
-?definite_pattern_value: NAME
-                       | "_"
-                       | "(" definite_pattern ")"
-                       | record_pattern
-tuple_pattern: (definite_pattern_value ",")+ definite_pattern_value
+?pattern: pattern_value
+        | tuple_pattern
+?pattern_value: NAME
+              | "_"
+              | "(" pattern ")"
+              | record_pattern
+              | list_pattern
+              | enum_pattern
+tuple_pattern: (pattern_value ",")+ pattern_value
 record_pattern: "{" (record_entry_pattern (";" | "\n"))* record_entry_pattern "}"
 ?record_entry_pattern: NAME
-                     | NAME ":" definite_pattern
+                     | NAME ":" pattern
 
-?cond_pattern: cond_pattern_value
-?cond_pattern_value: "(" cond_pattern_value ")"
-                   | list_pattern
-                   | enum_pattern
-list_pattern: "[" (any_pattern ("," any_pattern)*)? "]"
-enum_pattern: "<" NAME any_pattern* ">"
+list_pattern: "[" (pattern_value ("," pattern_value)*)? "]"
+enum_pattern: "<" NAME pattern_value* ">"
 
 // Boolean and number expressions, with order of operations.
 // Question mark "inlines" the branch, so we don't get nested

--- a/python/type.py
+++ b/python/type.py
@@ -157,11 +157,12 @@ def resolve_equal_types(type_a, type_b):
 	elif isinstance(type_a, NTypeVars):
 		if not isinstance(type_b, NTypeVars) or type_a.base_type is not type_b.base_type:
 			return None, True
+		base_type = type_a.base_type
 		resolved_typevars = []
 		for typevar_a, typevar_b in zip(type_a.typevars, type_b.typevars):
-			if isinstance(typevar_a, NGenericType) and typevar_a in type_a.base_type.typevars:
+			if isinstance(typevar_a, NGenericType) and typevar_a in base_type.typevars:
 				resolved_typevars.append(typevar_b)
-			elif isinstance(typevar_b, NGenericType) and typevar_b in type_a.base_type.typevars:
+			elif isinstance(typevar_b, NGenericType) and typevar_b in base_type.typevars:
 				resolved_typevars.append(typevar_a)
 			else:
 				resolved, problem = resolve_equal_types(typevar_a, typevar_b)

--- a/quirks.md
+++ b/quirks.md
@@ -1,0 +1,32 @@
+Since we have released N 1,
+we must maintain backwards compatibility
+in minor releases.
+This has resulted in poor decisions
+that must be kept in the language
+until the next major release of N.
+The following list documents these quirks
+that will likely be removed.
+
+- `imp filename` has been changed to `imp "filename.n"`
+to allow for import paths to other folders.
+
+- The `for i 10` syntax has been deprecated
+in favour of the `for (i in range(0, 10, 1))` syntax.
+The old syntax only allowed an integer literal.
+
+- Integer exponentiation returns a float
+because negative powers could result in a non-integer
+(this is a bug in Elm),
+but this is inconsistent with integer division,
+which truncates towards zero.
+This will likely be changed in the future
+to an int.
+
+- Record aliases now declare a constructor function,
+which was not the case,
+so the type checker won't stop you from having a function
+with the same name already defined.
+
+  - **BUG**: Declaring a variable
+  with the same name as an alias
+  will now raise an error.


### PR DESCRIPTION
- FEAT: Type aliases now make constructor functions if they're an alias for a record
- FEET: The `result` type
- FEAT: Concatenating lists
- Fixed an error if `N_WS_DEBUG` isn't set
- Division by zero no longer raises a runtime error
- Function type annotations
- Support for definite patterns in conditional patterns (ie `if let`)

```ts
alias person[n] = { name: str; age: int; height: n }

// Declares a value named `person` with the following type:
// person : [n] str -> int -> n -> person[n]
```

```ts
type result[o, e] = <ok o>
  | <err e>
```