### PR TITLE
Allow keywords and reserved words as record field names

### DIFF
--- a/python/run.n
+++ b/python/run.n
@@ -8,4 +8,7 @@ class Bit [value:int] {
 		return internal
 	}
 }
-let b = Bit("test")
+
+let { return: wow }: { return: int } = { return: 3 }
+let b = Bit(wow)
+print(b.toInt())

--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -50,11 +50,11 @@ char: "\\" ( escape_code | "{" /./ "}")
 escape_code: /[tnr]/
 tupledef: "(" types ("," types)* ")"
 recorddef: "{" (record_entry_def (";" | "\n"))* record_entry_def (";" | "\n")? "}"
-record_entry_def: NAME ":" types
+record_entry_def: CNAME ":" types
 with_typevars: module_type "[" types ("," types)* "]"
 declaration_with_typevars: NAME ("[" NAME ("," NAME)* "]")?
-tupleval: "(" expression ("," expression)* (",")? ")" 
-listval: "[" (expression ("," expression)* (",")?)? "]" 
+tupleval: "(" expression ("," expression)* (",")? ")"
+listval: "[" (expression ("," expression)* (",")?)? "]"
 recordval: "{" (record_entry (";" | "\n"))* record_entry (";" | "\n")? "}"
 enum_constructors: enum_constructor ("|" enum_constructor)*
 enum_constructor: modifier "<" NAME types* ">"
@@ -63,7 +63,7 @@ enum_constructor: modifier "<" NAME types* ">"
 
 modifier: PUBLIC?
 
-?record_entry: NAME ":" expression
+?record_entry: CNAME ":" expression
              | NAME
 
 ?pattern: pattern_value
@@ -77,7 +77,7 @@ modifier: PUBLIC?
 tuple_pattern: (pattern_value ",")+ pattern_value
 record_pattern: "{" (record_entry_pattern (";" | "\n"))* record_entry_pattern "}"
 ?record_entry_pattern: NAME
-                     | NAME ":" pattern
+                     | CNAME ":" pattern
 
 list_pattern: "[" (pattern_value ("," pattern_value)*)? "]"
 enum_pattern: "<" NAME pattern_value* ">"


### PR DESCRIPTION
Fixes #97 

```js
let { return: wow }: { return: int } = { return: 3 }
```

is no longer an issue. You can't do `let { return } = { return: 3 }` though