### PR TITLE
Fix typo

### DIFF
--- a/python/syntax.lark
+++ b/python/syntax.lark
@@ -138,7 +138,7 @@ func_type: generic_declaration? (func_inner_type "->")+ not_func_type
 ?await_expression: record_access
                  | await_expression AWAIT
 ?record_access: value
-              | record_access "." NAME
+              | record_access "." CNAME
 value: NUMBER
      | BOOLEAN
      | STRING


### PR DESCRIPTION
Fixed a typo in the `record_access` terminal.