### PR TITLE
Python syntax tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ pip install websockets
 # If there is a --check flag then it will only do compile-time and show warnings
 python n.py
 
+# Test syntax
+python -m unittest parse_test.py
+
 # OPTIONAL: Check the code for accidental errors
 # https://stackoverflow.com/a/31908039
 # https://stackoverflow.com/a/54488818

--- a/python/n.py
+++ b/python/n.py
@@ -10,7 +10,7 @@ from sys import exit
 init()
 
 from file import File
-from parser import n_parser
+from parse import n_parser
 from native_functions import add_funcs
 from type_check_error import TypeCheckError
 from scope import Scope

--- a/python/n.py
+++ b/python/n.py
@@ -10,24 +10,13 @@ from sys import exit
 init()
 
 from file import File
+from parser import n_parser
 from native_functions import add_funcs
 from type_check_error import TypeCheckError
 from scope import Scope
 from imported_error import ImportedError
 from cmd import Cmd
 from syntax_error import format_error
-
-# https://stackoverflow.com/a/4381638
-basepath = ""
-if getattr(sys, 'frozen', False):
-    basepath = path.dirname(sys.executable)
-elif __file__:
-    basepath = path.dirname(__file__)
-
-syntaxpath = path.join(basepath, "syntax.lark")
-with open(syntaxpath, "r") as f:
-	parse = f.read()
-n_parser = Lark(parse, start="start", propagate_positions=True)
 
 parser = argparse.ArgumentParser(description='Allows to only show warnings and choose the file location')
 parser.add_argument('--file', type=str, default="run.n", help="The file to read. (optional. if not included, it'll just run run.n)")
@@ -57,7 +46,7 @@ def type_check(file, tree):
 			[warning.display('warning', file) for warning in scope.warnings] +
 			[error.display('error', file) for error in scope.errors]
 		))
-		
+
 	return (len(scope.errors), len(scope.warnings))
 
 async def parse_tree(tree):

--- a/python/parse.py
+++ b/python/parse.py
@@ -1,5 +1,5 @@
 import sys
-import path
+from os import path
 
 from lark import Lark
 import lark

--- a/python/parse_test.py
+++ b/python/parse_test.py
@@ -1,3 +1,5 @@
+# python -m unittest parse_test.py
+
 import unittest
 from os import walk, path
 import re
@@ -5,22 +7,24 @@ import re
 from parse import n_parser, basepath
 
 class SyntaxTestCases(unittest.TestCase):
-	pass
+	@classmethod
+	def add_syntax_test_case(cls, file_name):
+		file_path = path.join(basepath, "../tests/syntax/", file_name)
+		def test_method(self):
+			with open(file_path, "r") as file:
+				parts = re.split(r"(?:\r?\n){3}", file.read())
+				tree, *other_trees = [n_parser.parse(part) for part in parts]
+				for other_tree in other_trees:
+					self.assertEqual(tree, other_tree)
+		# Dynamically add methods to the class https://stackoverflow.com/a/17930262
+		setattr(cls, 'test_' + re.sub(r"\W", '_', file_name[0:-2]), test_method)
 
 # Get files in directory https://stackoverflow.com/a/3207973
 _, _, file_names = next(walk(path.join(basepath, "../tests/syntax/")))
 for file_name in file_names:
 	if not file_name.endswith('.n'):
 		continue
-	file_path = path.join(basepath, "../tests/syntax/", file_name)
-	def test_method(self):
-		with open(file_path, "r") as file:
-			parts = re.split(r"(\r?\n){3}", file.read())
-			tree, *other_trees = [n_parser.parse(part) for part in parts]
-			for other_tree in other_trees:
-				self.assertEqual(tree, other_tree)
-	# Dynamically add methods to the class https://stackoverflow.com/a/17930262
-	setattr(SyntaxTestCases, 'test_' + re.sub(r"\W", '_', file_name[0:-2]), test_method)
+	SyntaxTestCases.add_syntax_test_case(file_name)
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/parse_test.py
+++ b/python/parse_test.py
@@ -1,0 +1,26 @@
+import unittest
+from os import walk, path
+import re
+
+from parse import n_parser, basepath
+
+class SyntaxTestCases(unittest.TestCase):
+	pass
+
+# Get files in directory https://stackoverflow.com/a/3207973
+_, _, file_names = next(walk(path.join(basepath, "../tests/syntax/")))
+for file_name in file_names:
+	if not file_name.endswith('.n'):
+		continue
+	file_path = path.join(basepath, "../tests/syntax/", file_name)
+	def test_method(self):
+		with open(file_path, "r") as file:
+			parts = re.split(r"(\r?\n){3}", file.read())
+			tree, *other_trees = [n_parser.parse(part) for part in parts]
+			for other_tree in other_trees:
+				self.assertEqual(tree, other_tree)
+	# Dynamically add methods to the class https://stackoverflow.com/a/17930262
+	setattr(SyntaxTestCases, 'test_' + re.sub(r"\W", '_', file_name[0:-2]), test_method)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/parser.py
+++ b/python/parser.py
@@ -1,19 +1,18 @@
-from lark import Lark
 import sys
+import path
+
+from lark import Lark
 import lark
 
-file = "run.n"
-if len(sys.argv) > 1:
-	file = ''.join(sys.argv[1:]) 
+# https://stackoverflow.com/a/4381638
+basepath = ""
+if getattr(sys, "frozen", False):
+	basepath = path.dirname(sys.executable)
+elif __file__:
+	basepath = path.dirname(__file__)
 
-parse = ""
-text = ""
-with open("syntax.lark", "r") as f:
+syntaxpath = path.join(basepath, "syntax.lark")
+with open(syntaxpath, "r") as f:
 	parse = f.read()
-with open(file, "r") as f:
-	text = f.read()
 
-n_parser = Lark(parse, start='start')
-
-print(n_parser.parse(text).pretty())
-print(n_parser.parse(text))
+n_parser = Lark(parse, start="start", propagate_positions=True)

--- a/tests/syntax/multiline-comments.n
+++ b/tests/syntax/multiline-comments.n
@@ -4,6 +4,8 @@
 
 /* /* Nested */ */
 
+// Ignored multiline comment /*
+
 /*
 	We're
 */let/*


### PR DESCRIPTION
You can now do

```sh
python -m unittest parse_test.py
```

and it'll perform all the tests in tests/syntax.

Currently, the Python branch fails all three syntax tests:

```py
FFE
======================================================================
ERROR: test_suffix (parse_test.SyntaxTestCases)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\seant\Documents\test\N-lang\python\parse_test.py", line 16, in
test_method
    tree, *other_trees = [n_parser.parse(part) for part in parts]
  File "C:\Users\seant\Documents\test\N-lang\python\parse_test.py", line 16, in
<listcomp>
    tree, *other_trees = [n_parser.parse(part) for part in parts]
  File "C:\Users\seant\AppData\Local\Programs\Python\Python38-32\lib\site-packag
es\lark\lark.py", line 517, in parse
    return self.parser.parse(text, start=start)
  File "C:\Users\seant\AppData\Local\Programs\Python\Python38-32\lib\site-packag
es\lark\parser_frontends.py", line 112, in parse
    return self.parser.parse(text, start)
  File "C:\Users\seant\AppData\Local\Programs\Python\Python38-32\lib\site-packag
es\lark\parsers\earley.py", line 298, in parse
    to_scan = self._parse(lexer, columns, to_scan, start_symbol)
  File "C:\Users\seant\AppData\Local\Programs\Python\Python38-32\lib\site-packag
es\lark\parsers\xearley.py", line 141, in _parse
    to_scan = scan(i, to_scan)
  File "C:\Users\seant\AppData\Local\Programs\Python\Python38-32\lib\site-packag
es\lark\parsers\xearley.py", line 117, in scan
    raise UnexpectedCharacters(stream, i, text_line, text_column, {item.expect.n
ame for item in to_scan},
lark.exceptions.UnexpectedCharacters: No terminal defined for '.' at line 4 col
11

print(one!.two!(3, 4)!(5, 6).seven(8, 9))
          ^
Expected one of:
        * __ANON_2
        * LPAR
        * LESS
        * LORE
        * RPAR
        * GORE
        * SUBTRACT
        * COMMA
        * DIVIDE
        * ADD
        * GREATER
        * EQUALS
        * EXPONENT
        * AND
        * NEQUALS
        * MODULO
        * AWAIT
        * MULTIPLY
        * OR


======================================================================
FAIL: test_function_calls (parse_test.SyntaxTestCases)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\seant\Documents\test\N-lang\python\parse_test.py", line 18, in
test_method
    self.assertEqual(tree, other_tree)
AssertionError: Tree([2148 chars]', [Token('NAME', 'main')])])]), Tree('instruc[
800 chars])])]) != Tree([2148 chars]', [Tree('function_callback_pipe', [Tree('fu
nc[848 chars])])])

======================================================================
FAIL: test_multiline_comments (parse_test.SyntaxTestCases)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\seant\Documents\test\N-lang\python\parse_test.py", line 18, in
test_method
    self.assertEqual(tree, other_tree)
AssertionError: Tree('start', []) != Tree('start', [Tree('instruction', [Tree('d
eclare', [Tre[737 chars])])])

----------------------------------------------------------------------
Ran 3 tests in 0.704s

FAILED (failures=2, errors=1)
```

This PR doesn't aim to fix them, and I don't think we should hold back the release of N 1.2 to fix them