### PR TITLE
Make tests from the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignored
+ignored

--- a/tests/assertions/README.md
+++ b/tests/assertions/README.md
@@ -1,0 +1,33 @@
+# N assertion test suite
+
+The `assertions` folder aims to test every single edge case to ensure:
+
+- No unsound programs pass
+
+- Parity between different N implementations
+
+- No "surprises"
+
+- Functions return proper values
+
+Each N file should
+
+1. parse correctly
+
+2. type check successfully
+
+  - Note that this makes use of the `assert type` statement, which should raise
+    a type error if the expression and type are incompatible.
+
+3. pass `assert value` statements successfully
+
+  - This makes use of the `assert value` statement, which when run in testing
+    mode (i.e. for these tests) should be executed at least once and be given
+    `true`.
+
+  - If an `assert value` statement is never executed, the test fails.
+
+  - If the `assert value` statement is given `false`, the test fails.
+
+  - `assert value` should only be given a bool, but this should be enforced by
+    the type checker in step 2.

--- a/tests/assertions/aliases.n
+++ b/tests/assertions/aliases.n
@@ -1,0 +1,9 @@
+// Based on docs/features/aliases.md
+
+alias test = {
+	a: int
+	b: int
+	c: str
+}
+
+assert type { a: 1; b: 1; c: "test" } : test

--- a/tests/assertions/async.n
+++ b/tests/assertions/async.n
@@ -1,0 +1,4 @@
+// Based on docs/features/async.md
+
+// TODO: The async example is pretty bad at the moment because it doesn't show
+// an actual use of async

--- a/tests/assertions/classes.n
+++ b/tests/assertions/classes.n
@@ -1,0 +1,19 @@
+// Based on docs/features/classes.md
+
+class pub Test [a:int b:int] {
+	let pub sum = [] -> int {
+		return a + b
+	}
+
+	let internalSum = a + b
+}
+
+assert type Test : int -> int -> Test
+
+let test = Test(1, 2)
+
+assert type test : Test
+
+assert type test.sum : int
+
+assert value test.sum = 1 + 2

--- a/tests/assertions/currying.n
+++ b/tests/assertions/currying.n
@@ -1,0 +1,13 @@
+// Based on docs/features/currying.md
+
+let sum = [a:int b:int] -> int {
+	return a + b
+}
+
+let addOne = sum(1)
+
+assert type addOne : int -> int
+
+assert value addOne(2) = 3
+
+assert value 2 |> sum(1) = 3

--- a/tests/assertions/destructuring.n
+++ b/tests/assertions/destructuring.n
@@ -1,0 +1,17 @@
+// Based on docs/features/destructuring.md
+
+let a, b = 1, 2
+assert value a = 1
+assert value b = 2
+
+let { x; z: y } = { x: 1; z: 1 }
+assert value x = 1
+assert value z = 1
+
+if let [a, b] = [1, 2] {
+	assert value (a, b) = (1, 2)
+}
+
+if let <yes a> = yes("test") {
+	assert value a = "test"
+}

--- a/tests/assertions/enums.n
+++ b/tests/assertions/enums.n
@@ -1,0 +1,46 @@
+// Based on docs/features/enums.md
+
+{
+	type state = mainMenu | ongoing | ended
+
+	assert type mainMenu : state
+
+	let gameState = ended
+
+	assert type gameState : state
+}
+
+{
+	type state =
+		| mainMenu
+		| <ongoing int>
+		| <ended str>
+
+	assert type ongoing : int -> state
+
+	let gameState = ongoing(100)
+
+	assert value gameState = ongoing(100)
+
+	if let <ongoing health> = gameState {
+		assert value health = 100
+	}
+}
+
+let divideBy2 = [number: int] -> result[int, string] {
+	if number % 2 = 1 {
+		return err("Odd numbers are not divisible by two.")
+	} else if not number = 42 {
+		return ok(number / 2)
+	} else {
+		return err("I have decided to refuse to divide 42 by two.")
+	}
+}
+
+assert value divideBy2(3) = err("Odd numbers are not divisible by two.")
+assert value divideBy2(42) = err("I have decided to refuse to divide 42 by two.")
+assert value divideBy2(10) = ok(5)
+
+if let <yes char> = "yes" |> charAt(0) {
+	assert value char = \{y}
+}

--- a/tests/assertions/for-loops.n
+++ b/tests/assertions/for-loops.n
@@ -1,0 +1,13 @@
+// Based on docs/features/for_loops.md
+
+for (i in range(0, 10, 1)) {
+	assert type i : int
+}
+
+for i 1 {
+	assert value i = 0
+}
+
+for (i in ["a", "b", "c"]) {
+	assert type i : str
+}

--- a/tests/assertions/generic.n
+++ b/tests/assertions/generic.n
@@ -1,0 +1,24 @@
+// Based on docs/features/generic.md
+
+assert type print : [t] t -> t
+
+assert type print("Hello!") : str
+assert type print(3.14) : float
+
+assert type filterMap : [a, b] (a -> maybe[b]) -> list[a] -> list[b]
+
+let map: [a, b] (a -> b) -> list[a] -> list[b] = [[x, y] transform:(x -> y) list:list[x]] -> list[y] {
+	let filter: x -> maybe[y] = [item: x] -> maybe[y] {
+		return yes(item)
+	}
+	return list |> filterMap(filter)
+}
+
+assert type map : [a, b] (a -> b) -> list[a] -> list[b]
+
+assert type map(intInBase10) : list[int] -> list[str]
+
+alias triplet[t] = (t, t, t)
+assert type (0.5, -0.5, 3.14) : triplet[float]
+
+assert type err("Failure!") : result[int, str]

--- a/tests/assertions/if-statements.n
+++ b/tests/assertions/if-statements.n
@@ -1,0 +1,25 @@
+// Based on docs/features/if_statements.md
+
+if 1 /= 1 {
+	print("This will never run")
+} else if (false) {
+	print("This will never run")
+} else {
+	assert value true
+}
+
+if let i = "This will always run" {
+	assert value i = "This will always run"
+}
+
+let notNone: maybe[str] = yes("This will always run")
+
+if let <yes test> = notNone {
+	assert value test = "This will always run"
+}
+
+if let <yes test> = none {
+	print("This will never run")
+} else {
+	assert value true
+}

--- a/tests/assertions/importing-n-files.n
+++ b/tests/assertions/importing-n-files.n
@@ -1,0 +1,5 @@
+// Based on docs/features/importing_n_files.md
+
+let importedThings = imp "./import.n"
+
+assert value importedThings.test = "hello"

--- a/tests/assertions/imports/import.n
+++ b/tests/assertions/imports/import.n
@@ -1,0 +1,4 @@
+let pub test = "Hello"
+let test2 = "Goodbye"
+
+print("test")

--- a/tests/assertions/internal-libraries.n
+++ b/tests/assertions/internal-libraries.n
@@ -1,0 +1,107 @@
+// Based on docs/features/internal_libraries.md
+
+let pub main = [_: ()] -> cmd[()] {
+	import fek
+
+	assert type fek.paer : str -> cmd[()]
+	assert value fek.paer("hi")! = ()
+
+	import FileIO
+
+	assert type FileIO.write : str -> str -> cmd[()]
+	assert value FileIO.write("./ignored/test.txt", "test")! = ()
+
+	assert type FileIO.append : str -> str -> cmd[()]
+	assert value FileIO.append("./ignored/test.txt", "test")! = ()
+
+	assert type FileIO.read : str -> cmd[maybe[str]]
+	// QUESTION: Is there a trailing newline?
+	assert value FileIO.read("./ignored/test.txt")! = "testtest"
+
+	import json
+
+	let value = json.object(mapFrom([
+		("test", json.string("test"))
+	]))
+	assert type value : json.value
+
+	assert type json.stringify : json.value -> str
+	assert value json.stringify(value) = "{\"test\":\"test\"}"
+
+	assert type json.parse : str -> json.value
+	assert value json.parse("{ test: \"test\" }") = json.null
+	assert value json.parse("{ \"test\": \"test\" }") = value
+
+	assert type json.parseSafe : str -> maybe[json.value]
+	assert value json.parseSafe("{ test: \"test\" }") = none
+	assert value json.parseSafe("{ \"test\": \"test\" }") = yes(value)
+
+	import request
+
+	assert type request.get : str -> map[str, str] -> cmd[{
+		code: int
+		response: str
+		return: json.value
+	}]
+	assert value request.get("https://httpbin.org/base64/SFRUUEJJTiBpcyBhd2Vzb21l", mapfrom([]))! = {
+		code: 200
+		response: "OK"
+		return: json.string("HTTPBIN is awesome")
+	}
+	assert value request.get("definitely invalid url", mapfrom([("","")]))! = {
+		code: 0
+		response: ""
+		return: json.null
+	}
+
+	assert type request.post : str -> map[str, str] -> map[str, str] -> cmd[{
+		code: int
+		response: str
+		text: str
+	}]
+	let response = request.post("https://httpbin.org/post", mapFrom([]), mapfrom([]))!
+	assert value (response.code, response.response) = (200, "OK")
+	assert value len(response.text) > 100
+	assert value request.post("definitely invalid url", mapFrom(["hello", "hello"]), mapfrom([("","")]))! = {
+		code: 0
+		response: ""
+		text: ""
+	}
+
+	import SystemIO
+
+	assert type SystemIO.imp : str -> cmd[str]
+	// TODO: How to test SystemIO.imp?
+
+	import times
+
+	assert type times.sleep : int -> cmd[()]
+	// TODO: How to test times.sleep?
+
+	import websocket
+
+	assert type websocket.connect : websocketconnectOptions -> str -> cmd[maybe[str]]
+
+	assert value websocket.connect({
+		onOpen: [send: websocket.send] -> cmd[bool] {
+			assert type send : str -> cmd[()]
+			send("hi")!
+			return false
+		}
+		onMessage: [send: websocket.send message: str] -> cmd[bool] {
+			assert type send : str -> cmd[()]
+			assert value message = "hi" | message = "hello"
+			send("hello")!
+			return message == "hello"
+		}
+	}, "wss://echo.websocket.org")! = none
+
+	assert value websocket.connect({
+		onOpen: [send: websocket.send] -> cmd[bool] {
+			return true
+		}
+		onMessage: [send: websocket.send message: str] -> cmd[bool] {
+			return true
+		}
+	}, "definitely invalid url")! /= none
+}

--- a/tests/assertions/native-functions.n
+++ b/tests/assertions/native-functions.n
@@ -1,0 +1,104 @@
+// Based on docs/features/native_functions.md
+
+assert type intInBase10 : int -> str
+assert value intInBase10(10) = "10"
+
+assert type round : float -> int
+assert value round(10.5) = 11
+assert value round(-10.5) = -10
+
+assert type floor : float -> int
+assert value floor(10.5) = 10
+assert value floor(-10.5) = -11
+
+assert type ceil : float -> int
+assert value ceil(10.5) = 11
+assert value ceil(10.4) = 11
+assert value ceil(-10.5) = -10
+
+assert type charCode : char -> int
+assert value charCode(\{a}) = 97
+assert value charCode(\{🕴}) = 0x1f574
+
+assert type intCode : int -> char
+assert value intCode(32) = \{ }
+assert value intCode(-1) = \u{FFFD}
+
+assert type charAt : int -> str -> maybe[char]
+assert value charAt(1, "abc") = yes(\{b})
+assert value charAt(-1, "abc") = none
+
+assert type substring : int -> int -> str -> str
+assert value substring(0, 2, "abc") = "ab"
+assert value substring(-3, -1, "apple sauce") = "uc"
+assert value substring(0, -1, "banana jam") = "banana ja"
+assert value substring(0, 100, "hi") = "hi"
+assert value substring(2, 100, "hi") = ""
+assert value substring(5, 3, "hello world") = ""
+
+assert type len : [t] t -> int
+assert value len("abc") = 3
+assert value len(100) = 0
+
+assert type split : char -> string -> list[str]
+assert value split(\{b}, "abc") = [b]
+assert value split(\{b}, "") = []
+assert value split(\{b}, "apple") = ["apple"]
+
+assert type strip : str -> str
+assert value strip(" abc ") = "abc"
+
+assert type range : int -> int -> int -> list[int]
+assert value range(0, 3, 1) = [0, 1, 2]
+// From https://docs.python.org/3/library/stdtypes.html#range
+assert value range(0, 10, 1) = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+assert value range(1, 11, 1) = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+assert value range(0, 30, 5) = [0, 5, 10, 15, 20, 25]
+assert value range(0, 10, 3) = [0, 3, 6, 9]
+assert value range(0, -10, -1) = [0, -1, -2, -3, -4, -5, -6, -7, -8, -9]
+assert value range(0, 0, 1) = []
+assert value range(1, 0) = []
+
+// `type` is not a "function" per se
+assert value type(10.0) = "float"
+
+assert type print : [t] t -> t
+assert value print("test") = "test"
+
+assert type itemAt : [t] int -> list[t] -> maybe[t]
+assert value itemAt(1, [1, 2, 3]) = yes(2)
+assert value itemAt(-1, [1, 2, 3]) = none
+
+assert type append : [t] t -> list[t] -> list[t]
+let list = [1, 2, 3]
+assert value append(4, list) = [1, 2, 3, 4]
+// `list` should not be mutated
+assert value list = [1, 2, 3]
+
+assert type filterMap : [a, b] (a -> maybe[b]) -> list[a] -> list[b]
+assert value filterMap([value:int] -> maybe[int] {
+	return yes(value * value + 1)
+}, [0, 1, 2, 3, 4]) = [1, 2, 5, 10, 17]
+
+assert type default : [t] t -> maybe[t] -> t
+assert value default("test1", yes("test")) = "test"
+assert value default("test1", none) = "test1"
+
+assert type then : [a, b] (a -> cmd[b]) -> cmd[a] -> cmd[b]
+import FileIO
+assert type then([text: str] -> cmd[()] {
+	assert value len(text) > 0
+}, FileIO.read("./README.md")) : cmd[()]
+
+assert type mapFrom : [k, v] list[(k, v)] -> map[k, v]
+let map = mapFrom([("a", 1), ("b", 2)])
+assert type map : map[str, int]
+
+assert type getValue : [k, v] k -> map[k, v] -> maybe[v]
+assert value getValue("b", map) = yes(2)
+assert value getValue("c", map) = none
+// TODO: N currently allows functions and commands as keys; how should they be
+// dealt with?
+
+assert type entries : [k, v] map[k, v] -> list[(k, v)]
+assert value entries(map) = [("a", 1), ("b", 2)]

--- a/tests/assertions/tuples-lists-records.n
+++ b/tests/assertions/tuples-lists-records.n
@@ -1,0 +1,9 @@
+// Based on docs/features/tuples_lists_records.md
+
+assert type 1, \{a} : int, char
+
+let recordValue = { value: 1 }
+assert type recordValue : { value: int }
+assert type recordValue.value : int
+
+assert type ["a", "b", "c"] : list[str]

--- a/tests/assertions/variables.n
+++ b/tests/assertions/variables.n
@@ -1,0 +1,9 @@
+// Based on docs/features/variables.md
+
+let test: str = "test"
+assert type test : str
+assert value test = "test"
+
+let test2 = 1
+assert type test2 : int
+assert value test2 = 1


### PR DESCRIPTION
This way, we can ensure that N has no surprising behaviour because surprises are not something you want to see in a programming langauge.

Both the Python and the JS implementations need to implement #117 in order to use these tests, but these tests are also helpful for documentation

In short, to use these tests, we need to add the following to the Python implementation.

- `assert test`, which just creates a type error if the given expression doesn't match the given type (it's more clear than doing `let _: type = expr`

- `assert value`, which when run in testing mode will throw runtime errors if it is given `false` or if it is never run after the exported `cmd`s finish executing