### PR TITLE
Add a stack trace

### DIFF
--- a/python/file.py
+++ b/python/file.py
@@ -36,7 +36,7 @@ class File:
     def get_text(self):
         return "\n".join(self.lines)
 
-    def display(self, start_line, start_col, end_line, end_col, color=Fore.RED):
+    def display(self, start_line, start_col, end_line, end_col, color=Fore.RED, underline=True):
         output = []
         if start_line == end_line:
             line = self.get_line(start_line)
@@ -45,8 +45,7 @@ class File:
             )
             output.append(
                 " " * (self.line_num_width + 2 + start_col)
-                + color
-                + "^" * (end_col - start_col)
+                + f"{color + '^' * (end_col - start_col) if underline else ''}"
                 + Style.RESET_ALL
             )
         else:
@@ -56,19 +55,19 @@ class File:
                 if line_num == start_line:
                     line = (
                         line[: start_col - 1]
-                        + Fore.RED
+                        + f"{color if underline else ''}"
                         + line[start_col - 1 :]
                         + Style.RESET_ALL
                     )
                 elif line_num == end_line:
                     line = (
-                        Fore.RED
+                        f"{color if underline else ''}"
                         + line[: end_col - 1]
                         + Style.RESET_ALL
                         + line[end_col - 1 :]
                     )
                 else:
-                    line = Fore.RED + line + Style.RESET_ALL
+                    line = f"{color if underline else ''}" + line + Style.RESET_ALL
                 output.append(
                     f"{Fore.CYAN}{line_num:>{self.line_num_width}} | {Style.RESET_ALL}{line}"
                 )

--- a/python/file.py
+++ b/python/file.py
@@ -43,11 +43,12 @@ class File:
             output.append(
                 f"{Fore.CYAN}{start_line:>{self.line_num_width}} | {Style.RESET_ALL}{line}"
             )
-            output.append(
-                " " * (self.line_num_width + 2 + start_col)
-                + f"{color + '^' * (end_col - start_col) if underline else ''}"
-                + Style.RESET_ALL
-            )
+            if underline:
+                output.append(
+                    " " * (self.line_num_width + 2 + start_col)
+                    + f"{color + '^' * (end_col - start_col) if underline else ''}"
+                    + Style.RESET_ALL
+                )
         else:
             for line_num, line in enumerate(
                 self.get_lines(start_line, end_line), start=start_line

--- a/python/n.py
+++ b/python/n.py
@@ -115,7 +115,7 @@ def type_check(file, tree):
             warning_len += len(warning)
         else:
             warning_len += 1
-    eefreer.aasdf()
+
     return (error_len, warning_len)
 
 
@@ -131,6 +131,8 @@ async def parse_tree(tree):
     else:
         raise SyntaxError("Unable to run parse_tree on non-starting branch")
 
+    eefreer.aasdf()
+
 
 try:
     tree = file.parse(n_parser)
@@ -145,7 +147,7 @@ except Exception as err:
     debug = os.environ.get("N_ST_DEBUG") == "dev"
     if(debug):
         raise err
-    stack_trace.display(global_scope.stack_trace)
+    stack_trace.display(global_scope.stack_trace, False)
     exit()
 
 if error_count > 0 or args.check:
@@ -162,4 +164,13 @@ if error_count > 0 or args.check:
 
 if __name__ == "__main__":
     # https://github.com/aio-libs/aiohttp/issues/4324#issuecomment-676675779
-    asyncio.get_event_loop().run_until_complete(parse_tree(tree))
+
+    try:
+        asyncio.get_event_loop().run_until_complete(parse_tree(tree))    
+    except Exception as err:
+        debug = os.environ.get("N_ST_DEBUG") == "dev"
+        if(debug):
+            raise err
+        print(global_scope.stack_trace)
+        stack_trace.display(global_scope.stack_trace)
+        exit()

--- a/python/n.py
+++ b/python/n.py
@@ -1,3 +1,18 @@
+import lark
+import asyncio
+import sys
+import signal
+import argparse
+import os
+
+from os import path
+from colorama import init, Fore, Style
+from sys import exit, platform
+import requests
+from lark import Lark
+
+import stack_trace
+
 from syntax_error import format_error
 from ncmd import Cmd
 from imported_error import ImportedError
@@ -6,17 +21,7 @@ from type_check_error import TypeCheckError
 from native_functions import add_funcs
 from parse import n_parser
 from file import File
-from lark import Lark
-import lark
-import asyncio
-import sys
-import signal
-import argparse
-import os
-from os import path
-from colorama import init, Fore, Style
-from sys import exit, platform
-import requests
+
 
 init()
 
@@ -110,7 +115,7 @@ def type_check(file, tree):
             warning_len += len(warning)
         else:
             warning_len += 1
-
+    eefreer.aasdf()
     return (error_len, warning_len)
 
 
@@ -134,7 +139,14 @@ except lark.exceptions.UnexpectedCharacters as e:
 except lark.exceptions.UnexpectedEOF as e:
     format_error(e, file)
 
-error_count, warning_count = type_check(file, tree)
+try:
+    error_count, warning_count = type_check(file, tree)
+except Exception as err:
+    debug = os.environ.get("N_ST_DEBUG") == "dev"
+    if(debug):
+        raise err
+    stack_trace.display(global_scope.stack_trace)
+    exit()
 
 if error_count > 0 or args.check:
     error_s = ""

--- a/python/n.py
+++ b/python/n.py
@@ -128,10 +128,9 @@ async def parse_tree(tree):
             if variable.public and isinstance(variable.value, Cmd):
                 await variable.value.eval()
                 break
+        global_scope.stack_trace = scope.stack_trace[:]
     else:
         raise SyntaxError("Unable to run parse_tree on non-starting branch")
-
-    eefreer.aasdf()
 
 
 try:
@@ -171,6 +170,5 @@ if __name__ == "__main__":
         debug = os.environ.get("N_ST_DEBUG") == "dev"
         if(debug):
             raise err
-        print(global_scope.stack_trace)
         stack_trace.display(global_scope.stack_trace)
         exit()

--- a/python/run.n
+++ b/python/run.n
@@ -1,33 +1,108 @@
-print(2 << 3)
-print(match ("How are you?"){
-  "Who are you?" -> "I am an example."
-  "How are you?" -> "I am good."
-  "Why are you?" -> "Why are *you*?"
-  _ -> "I don't understand."
-})
+// This is a simple minesweeper project in N
+// Bugs:
+//  - Sometimes mines can be placed in the same spot (kinda fixed)
 
-for (i in range(0, 10, 1)) {
-	print(i)
+let legacy = imp "./legacy.n"
+let random = imp "./.mod/random/random.n"
+
+let BOARDSIZE = 7
+let MINECOUNT = 10
+let ADJACENT:list[int] = [-BOARDSIZE - 1, -BOARDSIZE, -BOARDSIZE + 1, -1, 1, BOARDSIZE - 1, BOARDSIZE, BOARDSIZE + 1] // All things to add to the index to get the adjacent squares
+let SPECIALCASES:list[list[int]] = [[-BOARDSIZE - 1, -BOARDSIZE, -1, BOARDSIZE - 1, BOARDSIZE], [-BOARDSIZE, -BOARDSIZE + 1, 1, BOARDSIZE, BOARDSIZE + 1]] // Edge cases to stop weird looping first is right edge second is left edge
+
+let board:list[int] = range(0, BOARDSIZE * BOARDSIZE, 1)
+													   |> filterMap([_: int] -> maybe[int] {
+															return yes(0)
+														}) // This just creates a list of 0s
+
+
+let printBoard = [] -> () {
+	let out = ""
+	for (i, e in legacy.enumerate(board)) {
+		if i % BOARDSIZE == 0 && i /= 0 {
+			print(out)
+			var out = (if e /= -1 {intInBase10(e)} else {"-"})
+		} else {
+			var out = out + (if e /= -1 {intInBase10(e)} else {"-"})
+		}
+	}
+
+	print(out)
 }
 
-let errer = [1, 2, 3]
-let spreadTest = [..errer, 5, 5, 5, ..errer]
+let getDiscord = [i:int] -> str {
+	if i == -1 {
+		return "||" + \{💥} + "||"
+	}
 
-print(3 in mapFrom([(1, 3), (4, 5)]))
-print("est" in "test")
-let r = {
-	test: 1
-	test1: 2
+	return "||" + intInBase10(i) + intCode(65039) + intCode(8419) + "||"
 }
 
-let c = {
-	..r
-	test1: 3
-	test2: "reer"
+let printDiscord = [] -> () {
+	let out = ""
+	for (i, e in legacy.enumerate(board)) {
+		if i % BOARDSIZE == 0 && i /= 0 {
+			print(out)
+			var out = getDiscord(e)
+		} else {
+			var out = out + getDiscord(e)
+		}
+	}
+
+	print(out)
 }
 
-print(c)
-print(spreadTest)
+let run = [] -> cmd[()] {
+	let epoch = legacy.getCurrentTime()!
 
-print(append(3, spreadTest))
-print(subsection(1, 100000, spreadTest))
+	let rand = random.createRandom(epoch)
+
+	let mines:list[int] = []
+
+	for (i in range(0, MINECOUNT, 1)) {
+		// Get the index of the time
+		let index = floor(rand.getNext() * BOARDSIZE^2)
+		
+		if (itemAt(index, board) |> default(0)) /= -1 { // does a really bad way of stopping duplicates from messing with things
+			// Set that to -1
+			var board = board
+							|> legacy.setItem(index, -1)
+
+			var mines = append(index, mines) // Store the location of the mine
+		}
+	}
+
+	// This increases all of the numbers if they are near a mine
+	for (mine in mines) {
+		let adjacentList = ADJACENT
+
+		// This code is for stopping looping when checking adjacents on the right and left edge
+		if (mine + 1) % BOARDSIZE == 0 {
+			var adjacentList = SPECIALCASES
+										  |> itemAt(0)
+										  |> default(ADJACENT)
+		} else if mine % BOARDSIZE == 0 {
+			var adjacentList = SPECIALCASES
+										  |> itemAt(1)
+										  |> default(ADJACENT)
+		}
+
+
+		// Get all adjacent squares and add one if it is not a mine
+		for (s in adjacentList) {
+			let square = itemAt(mine + s, board)
+			if let <yes adjacentSquare> = square { // Check if it exists
+				if adjacentSquare /= -1 { // Check if it is not a mine
+					var board = board
+							|> legacy.setItem(mine + s, adjacentSquare + 1)
+				}
+			}
+		}
+	}
+
+	printBoard()
+	print("")
+	printDiscord()
+}
+
+let pub main = run()

--- a/python/run.n
+++ b/python/run.n
@@ -1,108 +1,41 @@
-// This is a simple minesweeper project in N
-// Bugs:
-//  - Sometimes mines can be placed in the same spot (kinda fixed)
+let runner = imp "./runner.n"
 
-let legacy = imp "./legacy.n"
-let random = imp "./.mod/random/random.n"
+print(2 << 3)
+print(match ("How are you?"){
+  "Who are you?" -> "I am an example."
+  "How are you?" -> "I am good."
+  "Why are you?" -> "Why are *you*?"
+  _ -> "I don't understand."
+})
 
-let BOARDSIZE = 7
-let MINECOUNT = 10
-let ADJACENT:list[int] = [-BOARDSIZE - 1, -BOARDSIZE, -BOARDSIZE + 1, -1, 1, BOARDSIZE - 1, BOARDSIZE, BOARDSIZE + 1] // All things to add to the index to get the adjacent squares
-let SPECIALCASES:list[list[int]] = [[-BOARDSIZE - 1, -BOARDSIZE, -1, BOARDSIZE - 1, BOARDSIZE], [-BOARDSIZE, -BOARDSIZE + 1, 1, BOARDSIZE, BOARDSIZE + 1]] // Edge cases to stop weird looping first is right edge second is left edge
-
-let board:list[int] = range(0, BOARDSIZE * BOARDSIZE, 1)
-													   |> filterMap([_: int] -> maybe[int] {
-															return yes(0)
-														}) // This just creates a list of 0s
-
-
-let printBoard = [] -> () {
-	let out = ""
-	for (i, e in legacy.enumerate(board)) {
-		if i % BOARDSIZE == 0 && i /= 0 {
-			print(out)
-			var out = (if e /= -1 {intInBase10(e)} else {"-"})
-		} else {
-			var out = out + (if e /= -1 {intInBase10(e)} else {"-"})
-		}
-	}
-
-	print(out)
+for (i in range(0, 10, 1)) {
+	print(i)
 }
 
-let getDiscord = [i:int] -> str {
-	if i == -1 {
-		return "||" + \{💥} + "||"
-	}
+let errer = [1, 2, 3]
+let spreadTest = [..errer, 5, 5, 5, ..errer]
 
-	return "||" + intInBase10(i) + intCode(65039) + intCode(8419) + "||"
+print(3 in mapFrom([(1, 3), (4, 5)]))
+print("est" in "test")
+let r = {
+	test: 1
+	test1: 2
 }
 
-let printDiscord = [] -> () {
-	let out = ""
-	for (i, e in legacy.enumerate(board)) {
-		if i % BOARDSIZE == 0 && i /= 0 {
-			print(out)
-			var out = getDiscord(e)
-		} else {
-			var out = out + getDiscord(e)
-		}
-	}
-
-	print(out)
+let c = {
+	..r
+	test1: 3
+	test2: "reer"
 }
 
-let run = [] -> cmd[()] {
-	let epoch = legacy.getCurrentTime()!
+print(c)
+print(spreadTest)
 
-	let rand = random.createRandom(epoch)
+print(append(3, spreadTest))
+print(subsection(1, 100000, spreadTest))
 
-	let mines:list[int] = []
-
-	for (i in range(0, MINECOUNT, 1)) {
-		// Get the index of the time
-		let index = floor(rand.getNext() * BOARDSIZE^2)
-		
-		if (itemAt(index, board) |> default(0)) /= -1 { // does a really bad way of stopping duplicates from messing with things
-			// Set that to -1
-			var board = board
-							|> legacy.setItem(index, -1)
-
-			var mines = append(index, mines) // Store the location of the mine
-		}
-	}
-
-	// This increases all of the numbers if they are near a mine
-	for (mine in mines) {
-		let adjacentList = ADJACENT
-
-		// This code is for stopping looping when checking adjacents on the right and left edge
-		if (mine + 1) % BOARDSIZE == 0 {
-			var adjacentList = SPECIALCASES
-										  |> itemAt(0)
-										  |> default(ADJACENT)
-		} else if mine % BOARDSIZE == 0 {
-			var adjacentList = SPECIALCASES
-										  |> itemAt(1)
-										  |> default(ADJACENT)
-		}
-
-
-		// Get all adjacent squares and add one if it is not a mine
-		for (s in adjacentList) {
-			let square = itemAt(mine + s, board)
-			if let <yes adjacentSquare> = square { // Check if it exists
-				if adjacentSquare /= -1 { // Check if it is not a mine
-					var board = board
-							|> legacy.setItem(mine + s, adjacentSquare + 1)
-				}
-			}
-		}
-	}
-
-	printBoard()
-	print("")
-	printDiscord()
+let sum = [a:int b:int] -> int {
+	return a + b
 }
 
-let pub main = run()
+print(sum(1, 2))

--- a/python/runner.n
+++ b/python/runner.n
@@ -1,2 +1,5 @@
-let test:str = 0
-let test = "ree"
+let sum = [a:int b:int] -> int {
+	return a + b
+}
+
+print(sum(1, 2))

--- a/python/scope.py
+++ b/python/scope.py
@@ -174,6 +174,7 @@ class Scope:
         base_path="",
         file_path="",
         parent_type="top",
+        stack_trace=None,
     ):
         self.parent = parent
         self.parent_function = parent_function
@@ -189,7 +190,9 @@ class Scope:
         self.file_path = file_path
         self.parent_type = parent_type
 
-    def new_scope(self, parent_function=None, inherit_errors=True, parent_type=None):
+        self.stack_trace = stack_trace if stack_trace is not None else []
+
+    def new_scope(self, parent_function=None, inherit_errors=True, parent_type=None, inherit_stack_trace=True):
         return Scope(
             self,
             parent_function=parent_function or self.parent_function,
@@ -198,6 +201,7 @@ class Scope:
             base_path=self.base_path,
             file_path=self.file_path,
             parent_type=parent_type or self.parent_type,
+            stack_trace=self.stack_trace if inherit_stack_trace else [],
         )
 
     def get_variable(self, name, err=True):
@@ -1427,6 +1431,9 @@ class Scope:
                 function, *arguments = expr.children[1].children
                 arguments.append(mainarg)
             func_type = self.type_check_expr(function)
+            if isinstance(func_type, NativeFunction):
+                with open(self.file_path, "r", encoding="utf-8") as f:
+                    self.stack_trace.append((expr, File(f, name=os.path.relpath(self.file_path, start=self.base_path))))
             if func_type is None:
                 return None
             if not isinstance(func_type, tuple):
@@ -1746,7 +1753,9 @@ class Scope:
                 rel_file_path = expr.children[0].value + ".n"
             file_path = os.path.join(os.path.dirname(self.file_path), rel_file_path)
             if os.path.isfile(file_path):
-                impn, f = type_check_file(file_path, self.base_path)
+                impn, f = type_check_file(file_path, self.base_path)  
+                with open(self.file_path, "r", encoding="utf-8") as f:
+                    self.stack_trace.append((expr, File(f, name=os.path.relpath(self.file_path, start=self.base_path))))
                 if len(impn.errors) != 0:
                     self.errors.append(ImportedError(impn.errors[:], f))
                 if len(impn.warnings) != 0:

--- a/python/scope.py
+++ b/python/scope.py
@@ -960,7 +960,7 @@ class Scope:
             with open(self.file_path, "r", encoding="utf-8") as f:
                 self.stack_trace.append((expr, File(f, name=os.path.relpath(self.file_path, start=self.base_path))))
             val = await eval_file(file_path, self.base_path)
-            self.stack_trace = self.stack_trace.__add__(val.stack_trace[:])
+            self.stack_trace += val.stack_trace
             holder = {}
             for key in val.variables.keys():
                 if val.variables[key].public:

--- a/python/stack_trace.py
+++ b/python/stack_trace.py
@@ -1,15 +1,13 @@
 from colorama import Fore, Style
 
 def display(stack_trace, runtime=True):
-    print(stack_trace)
     if not runtime:
         print("An unexpected error occured! Please open an issue on GitHub https://github.com/nbuilding/N-Lang/issues. Set N_ST_DEBUG to \"dev\" to see the python stack trace.")
         return
     output = "An unexpected error occured! Please open an issue on GitHub https://github.com/nbuilding/N-Lang/issues. Printing out stack trace:\n"
     for trace in stack_trace:
         area, file = trace
-
-        spaces = " " * (len(str(file.line_num_width + 1) + " |") - 1)
+        spaces = " " * (len(str(area.line + 1) + " |") - 3)
         output += f"{Fore.CYAN}{spaces}--> {Fore.BLUE}{file.name}:{area.line}{Style.RESET_ALL}\n"
         output += file.display(
             area.line,
@@ -17,5 +15,5 @@ def display(stack_trace, runtime=True):
             area.end_line,
             area.end_column,
             underline=False,
-        )
+        ) + "\n"
     print(output)

--- a/python/stack_trace.py
+++ b/python/stack_trace.py
@@ -1,12 +1,16 @@
 from colorama import Fore, Style
 
-def display(stack_trace):
-    output = "An unexpected error occured! Please open an issue on GitHub https://github.com/nbuilding/N-Lang/issues. Printing out stack trace:\nbuilding"
+def display(stack_trace, runtime=True):
+    print(stack_trace)
+    if not runtime:
+        print("An unexpected error occured! Please open an issue on GitHub https://github.com/nbuilding/N-Lang/issues. Set N_ST_DEBUG to \"dev\" to see the python stack trace.")
+        return
+    output = "An unexpected error occured! Please open an issue on GitHub https://github.com/nbuilding/N-Lang/issues. Printing out stack trace:\n"
     for trace in stack_trace:
         area, file = trace
 
-        spaces = " " * (len(str(area.line) + " |") - 1)
-        output += f"{Fore.CYAN}--> {Fore.BLUE}{file.name}:{area.line}{Style.RESET_ALL}\n"
+        spaces = " " * (len(str(file.line_num_width + 1) + " |") - 1)
+        output += f"{Fore.CYAN}{spaces}--> {Fore.BLUE}{file.name}:{area.line}{Style.RESET_ALL}\n"
         output += file.display(
             area.line,
             area.column,

--- a/python/stack_trace.py
+++ b/python/stack_trace.py
@@ -1,0 +1,17 @@
+from colorama import Fore, Style
+
+def display(stack_trace):
+    output = "An unexpected error occured! Please open an issue on GitHub https://github.com/nbuilding/N-Lang/issues. Printing out stack trace:\nbuilding"
+    for trace in stack_trace:
+        area, file = trace
+
+        spaces = " " * (len(str(area.line) + " |") - 1)
+        output += f"{Fore.CYAN}--> {Fore.BLUE}{file.name}:{area.line}{Style.RESET_ALL}\n"
+        output += file.display(
+            area.line,
+            area.column,
+            area.end_line,
+            area.end_column,
+            underline=False,
+        )
+    print(output)


### PR DESCRIPTION
closes #190

## How it works

The stack trace will be shown when a runtime error occurs, as during compile time it is not really that useful because everything is evaluated top to bottom. The stack trace can be switched to the python stack trace by setting the environment variable `N_ST_DEBUG` to `dev`.