### PR TITLE
Add tests for the value access operator

### DIFF
--- a/tests/assertions/value-access.n
+++ b/tests/assertions/value-access.n
@@ -1,0 +1,40 @@
+// Lists
+
+let first = ["un", "du", "trois"][0]
+assert type first : maybe[str]
+assert value first == yes("un")
+
+let nested = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+assert type nested[-1][-1] : maybe[int]
+assert value nested[-1][-1] == none
+assert value nested[3][0] == none
+assert value nested[0][3] == none
+assert value nested[0][0] == yes(1)
+assert value nested[0][2] == yes(3)
+
+// Maps
+
+let sheep = mapFrom([("baa", "sheep"), ("moo", "cow")])["baa"]
+assert type sheep : maybe[str]
+assert value sheep == yes("sheep")
+
+let nestedMap = mapFrom([
+  (
+    "english",
+    mapFrom([
+      ("sheep", "a fluffy, ruminant animal"),
+      ("apple", "orangen't"),
+    ]),
+  ),
+])
+assert type nestedMap["english"]["apple"] : maybe[str]
+assert value nestedMap["english"]["apple"] == "orangen't"
+
+// Strings
+
+assert type "wow"[0] : maybe[char]
+assert value "wow"[0] == yes(\{w})
+assert value "wow"[-1] == none
+
+let strings = ["happy", "sheep", "goes", "boing"]
+assert value strings[3][2] == yes(\{e})

--- a/tests/assertions/value-access.n
+++ b/tests/assertions/value-access.n
@@ -37,4 +37,4 @@ assert value "wow"[0] == yes(\{w})
 assert value "wow"[-1] == none
 
 let strings = ["happy", "sheep", "goes", "boing"]
-assert value strings[3][2] == yes(\{e})
+assert value strings[3][2] == yes(\{i})

--- a/tests/syntax/value-access.n
+++ b/tests/syntax/value-access.n
@@ -1,0 +1,30 @@
+// Simple syntax test for the value access operator
+
+// The value access operator should be chainable like function calls and the
+// record access and await operators.
+let a = -b[if c { d } else { e }].f[[] -> () {}]![g |> h]()[i | j][[]]
+let b = [][()]
+
+
+let a = -(
+  (
+    (
+      (
+        (
+          (
+            (
+              (
+                (b)[(if c { d } else { e })]
+              ).f
+            )[([] -> () {})]
+          )!
+        )[(g |> h)]
+      )()
+    )([i | j)]
+  )[([])]
+)
+let b = (
+  // Allow a newline between the value and value access operator
+  []
+    [()]
+)


### PR DESCRIPTION
Currently the tests also include unapproved features I raised in #208:

- allowed newlines inside parentheses
- indexing characters from strings

If they remain unapproved I'll remove them from the tests

Resolves #208 by adding it to the test-based specification of N. Implementations will become noncompliant until they support this