### PR TITLE
Fix cmd helper functions when given return values from `cmd` procedures not using `!`

### DIFF
--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -77,7 +77,7 @@ def cmd_then(n_function, cmd):
 
 def cmd_parallel(cmd):
     async def in_parallel():
-        return await cmd.eval()
+        return await Cmd.wrap(cmd).eval()
 
     async def run_in_parallel():
         # Run `cmd` in parallel

--- a/python/native_functions.py
+++ b/python/native_functions.py
@@ -70,9 +70,9 @@ def with_default(default_value, maybe_value):
 
 def cmd_then(n_function, cmd):
     async def then(result):
-        return (await n_function.run([result])).eval
+        return await Cmd.wrap(await n_function.run([result])).eval()
 
-    return cmd.then(then)
+    return Cmd.wrap(cmd).then(lambda result: lambda: then(result))
 
 
 def cmd_parallel(cmd):

--- a/python/ncmd.py
+++ b/python/ncmd.py
@@ -52,3 +52,22 @@ class Cmd:
             repr(self.map_functions),
             repr(self.dependent),
         )
+
+    @classmethod
+    def from_value(Cls, value):
+        """
+        Create a Cmd that simply returns the given value.
+        """
+
+        return Cls(lambda _: lambda: value)
+
+    @classmethod
+    def wrap(Cls, maybe_cmd):
+        """
+        Ensures that `maybe_cmd` is a Cmd by wrapping it in one if it's not.
+        """
+
+        if isinstance(maybe_cmd, Cls):
+            return maybe_cmd
+        else:
+            return Cls.from_value(maybe_cmd)

--- a/tests/assertions/native-functions.n
+++ b/tests/assertions/native-functions.n
@@ -106,12 +106,20 @@ assert type then([text: maybe[str]] -> cmd[()] {
 let getData = () |> ([] -> cmd[map[str, str]] {
 	return mapFrom([("hi", "hello")])
 })
-let out = getData
+let thenCmd = getData
 	|> then(
 		[data:map[str, str]] -> cmd[()] {
 			assert value data == mapFrom([("hi", "hello")])
 		}
 	)
+
+assert type parallel : [t] cmd[t] -> cmd[cmd[t]]
+let parallelCmd = () |> ([] -> cmd[()] {
+	let _ = parallel(() |> ([] -> cmd[()] {
+		// See #227
+		assert value true
+	}))!
+})
 
 assert type mapFrom : [k, v] list[(k, v)] -> map[k, v]
 let map = mapFrom([("a", 1), ("b", 2)])
@@ -177,5 +185,6 @@ if let <yes module> = intoModule(imp "./imports/unit-test.n") {
 }
 
 let pub main = () |> ([] -> cmd[()] {
-	let _ = out!
+	let _ = thenCmd!
+	let _ = parallelCmd!
 })

--- a/tests/assertions/native-functions.n
+++ b/tests/assertions/native-functions.n
@@ -102,6 +102,17 @@ assert type then([text: maybe[str]] -> cmd[()] {
 	assert value len(text |> default("")) > 0
 }, FileIO.read("./README.md")) : cmd[()]
 
+// See #228
+let getData = () |> ([] -> cmd[map[str, str]] {
+	return mapFrom([("hi", "hello")])
+})
+let out = getData
+	|> then(
+		[data:map[str, str]] -> cmd[()] {
+			assert value data == mapFrom([("hi", "hello")])
+		}
+	)
+
 assert type mapFrom : [k, v] list[(k, v)] -> map[k, v]
 let map = mapFrom([("a", 1), ("b", 2)])
 assert type map : map[str, int]
@@ -164,3 +175,7 @@ if let <yes module> = intoModule(imp "./imports/unit-test.n") {
 		possibleTypes: none
 	})).fileLine == 9
 }
+
+let pub main = () |> ([] -> cmd[()] {
+	let _ = out!
+})


### PR DESCRIPTION
See added tests, which pass, I believe

Fixes #227 and fixes #228 