### PR TITLE
Define text encoding and int overflow behaviour for FileIO

### DIFF
--- a/tests/assertions/internal-libraries.n
+++ b/tests/assertions/internal-libraries.n
@@ -4,23 +4,26 @@ let pub main = [_: ()] -> cmd[()] {
 	import FileIO
 
 	assert type FileIO.write : str -> str -> cmd[()]
-	assert value FileIO.write("./ignored/test.txt", "test")! = ()
+	assert value FileIO.write("./ignored/test.txt", "test 🐑")! = ()
 
 	assert type FileIO.append : str -> str -> cmd[()]
-	assert value FileIO.append("./ignored/test.txt", "test")! = ()
+	assert value FileIO.append("./ignored/test.txt", "test 🐑")! = ()
+	
+	// Ensure that .write and .append encode text in UTF-8
+	assert value FileIO.readBytes("./ignored/test.txt")! == yes([116, 101, 115, 116, 32, 240, 159, 144, 145, 116, 101, 115, 116, 32, 240, 159, 144, 145])
 
 	assert type FileIO.read : str -> cmd[maybe[str]]
-	// QUESTION: Is there a trailing newline?
-	assert value FileIO.read("./ignored/test.txt")! = yes("testtest")
+	assert value FileIO.read("./ignored/test.txt")! = yes("test 🐑test 🐑")
 
 	assert type FileIO.writeBytes : str -> list[int] -> cmd[()]
 	assert value FileIO.writeBytes("./ignored/bytes.txt", [1, 2, 3])! == ()
 
 	assert type FileIO.appendBytes : str -> list[int] -> cmd[()]
-	assert value FileIO.appendBytes("./ignored/bytes.txt", [4, 5, 6])! == ()
+	// Out-of-bounds integers will overflow
+	assert value FileIO.appendBytes("./ignored/bytes.txt", [256, 257, -1])! == ()
 
 	assert type FileIO.readBytes : str -> cmd[maybe[list[int]]]
-	assert value FileIO.readBytes("./ignored/bytes.txt")! == yes([1, 2, 3, 4, 5, 6])
+	assert value FileIO.readBytes("./ignored/bytes.txt")! == yes([1, 2, 3, 0, 1, 255])
 
 	assert type FileIO.getFiles : str -> cmd[list[(bool, str)]]
 	let files = FileIO.getFiles("./ignored/")!


### PR DESCRIPTION
Normally, I would open this as an issue, but since the tests define the language, I might as well make a PR directly.

Currently, the the text encoding is undefined behaviour, so you cannot reliably use `FileIO.readBytes` on a file written by `FileIO.write`. I propose that we use UTF-8; this is indicated by the addition of the `FileIO.readBytes("./ignored/test.txt")!` test checking the bytes in the file.

Also, the behaviour of giving integers outside 0–255 is undefined behaviour. I propose that we allow the ints to overflow, like `int % 256`, so 256 becomes 0, 257 becomes 1, etc. And negative numbers will underflow, so -1 becomes 255. This is reflected in the test by giving `[256, 257, -1]` to `FileIO.appendBytes`